### PR TITLE
Use "." as default jq filter

### DIFF
--- a/main.go
+++ b/main.go
@@ -230,6 +230,12 @@ func _main() error {
 	if err != nil {
 		return err
 	}
+
+	// Overwrite to "." because gojq don't support empty query
+	if jqFilter == "" {
+		jqFilter = "."
+	}
+
 	jqQuery, err := gojq.Parse(jqFilter)
 
 	mode := spannerpb.ExecuteSqlRequest_QueryMode(spannerpb.ExecuteSqlRequest_QueryMode_value[o.QueryMode])


### PR DESCRIPTION
execspansql v0.2.1 is broken after #18.
```
$ execspansql --sql="SELECT 1" $DATABASE
2024/07/25 23:43:56 missing query (try ".")
```

It is caused by https://github.com/itchyny/gojq/releases/tag/v0.12.16.
>improve compiler to emit error if query is missing

https://github.com/itchyny/gojq/commit/0cd3a662ced371ca01cd21e89d8225501cc415f9

This PR fixes this bug.