### PR TITLE
Support ENUM, PROTO, FLOAT32

### DIFF
--- a/rowutil.go
+++ b/rowutil.go
@@ -46,8 +46,10 @@ func gcvToStringExperimental(value *spanner.GenericColumnValue) (string, error) 
 	switch value.Type.GetCode() {
 	case spannerpb.TypeCode_BOOL:
 		return gcvElemToStringExperimental[spanner.NullBool](value)
-	case spannerpb.TypeCode_INT64:
+	case spannerpb.TypeCode_INT64, spannerpb.TypeCode_ENUM:
 		return gcvElemToStringExperimental[spanner.NullInt64](value)
+	case spannerpb.TypeCode_FLOAT32:
+		return gcvElemToStringExperimental[spanner.NullFloat32](value)
 	case spannerpb.TypeCode_FLOAT64:
 		return gcvElemToStringExperimental[spanner.NullFloat64](value)
 	case spannerpb.TypeCode_TIMESTAMP:
@@ -56,7 +58,7 @@ func gcvToStringExperimental(value *spanner.GenericColumnValue) (string, error) 
 		return gcvElemToStringExperimental[spanner.NullDate](value)
 	case spannerpb.TypeCode_STRING:
 		return gcvElemToStringExperimental[spanner.NullString](value)
-	case spannerpb.TypeCode_BYTES:
+	case spannerpb.TypeCode_BYTES, spannerpb.TypeCode_PROTO:
 		return gcvElemToStringExperimental[nullBytes](value)
 	case spannerpb.TypeCode_ARRAY:
 		// Note: This format is not intended to be parseable.


### PR DESCRIPTION
```sql
WITH t AS (SELECT CAST('genre: POP, nationality: "Japan"' AS spanner.examples.music.SingerInfo) AS singer)
SELECT t.singer, t.singer.genre, CAST(0 AS FLOAT32)
FROM t
```

```
$ execspansql $DATABASE --sql-file types.sql --format=yaml    
metadata:
    rowType:
        fields:
            - name: singer
              type:
                code: 13
            - name: genre
              type:
                code: 14
            - type:
                code: 15
    transaction:
        readTimestamp: "2024-07-25T15:15:20.629902Z"
    undeclaredParameters: {}
rows:
    - - GgVKYXBhbiAA
      - "0"
      - 0
```
```
$ go run ./ $DATABASE --sql-file types.sql --format=yaml  
metadata:
    rowType:
        fields:
            - name: singer
              type:
                code: PROTO
                protoTypeFqn: spanner.examples.music.SingerInfo
            - name: genre
              type:
                code: ENUM
                protoTypeFqn: spanner.examples.music.Genre
            - type:
                code: FLOAT32
    transaction:
        readTimestamp: "2024-07-25T15:15:39.977068Z"
    undeclaredParameters: {}
rows:
    - - GgVKYXBhbiAA
      - "0"
      - 0
```