### PR TITLE
feat: stream experimental CSV from RowIterator

### DIFF
--- a/csv_golden_test.go
+++ b/csv_golden_test.go
@@ -16,8 +16,8 @@ func TestExperimentalCsvGolden(t *testing.T) {
 			goldenPath := filepath.Join("testdata", "experimental_csv", name+".golden")
 
 			var buf bytes.Buffer
-			if err := writeCsv(&buf, rs); err != nil {
-				t.Fatalf("writeCsv() error = %v", err)
+			if err := writeCsvFromResultSet(&buf, rs); err != nil {
+				t.Fatalf("writeCsvFromResultSet() error = %v", err)
 			}
 			got := buf.Bytes()
 
@@ -37,7 +37,7 @@ func TestExperimentalCsvGolden(t *testing.T) {
 				t.Fatalf("ReadFile(%q) error = %v (run: go test -update-golden -run TestExperimentalCsvGolden)", goldenPath, err)
 			}
 			if string(got) != string(want) {
-				t.Fatalf("writeCsv() output mismatch for %s\n\ngot:\n%s\n\nwant:\n%s", name, got, want)
+				t.Fatalf("writeCsvFromResultSet() output mismatch for %s\n\ngot:\n%s\n\nwant:\n%s", name, got, want)
 			}
 		})
 	}

--- a/csv_test.go
+++ b/csv_test.go
@@ -148,10 +148,12 @@ func experimentalCsvViaSpanvalueWriter(out *bytes.Buffer, rs *sppb.ResultSet) er
 	return csvWriter.Flush()
 }
 
-// writeCsvFromPreparedRows exercises the WriteRow path when metadata is already known
-// (equivalent to RowIterator export after PrepareRowType).
+// writeCsvFromPreparedRows exercises the WriteRow path after PrepareRowType, matching production.
 func writeCsvFromPreparedRows(w io.Writer, metadata *sppb.ResultSetMetadata, rows []*spanner.Row) error {
-	csvWriter := svwriter.NewCSVWriter(w, svwriter.WithMetadata(metadata))
+	csvWriter := svwriter.NewCSVWriter(w)
+	if err := prepareCsvRowType(csvWriter, metadata); err != nil {
+		return err
+	}
 	for _, row := range rows {
 		if err := csvWriter.WriteRow(row); err != nil {
 			return err

--- a/csv_test.go
+++ b/csv_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"flag"
+	"io"
 	"os"
 	"testing"
 
@@ -70,13 +71,8 @@ func TestExperimentalCsvRowIterPathMatchesResultSet(t *testing.T) {
 	if err := writeCsvFromResultSet(&fromResultSet, rs); err != nil {
 		t.Fatalf("writeCsvFromResultSet() error = %v", err)
 	}
-	if err := writeCsvWithMetadata(&fromRowIter, rs.GetMetadata(), func(yield func(*spanner.Row, error) bool) {
-		if !yield(row1, nil) {
-			return
-		}
-		yield(row2, nil)
-	}); err != nil {
-		t.Fatalf("writeCsvWithMetadata() error = %v", err)
+	if err := writeCsvFromPreparedRows(&fromRowIter, rs.GetMetadata(), []*spanner.Row{row1, row2}); err != nil {
+		t.Fatalf("writeCsvFromPreparedRows() error = %v", err)
 	}
 	if diff := cmp.Diff(fromResultSet.String(), fromRowIter.String()); diff != "" {
 		t.Fatalf("RowIterator path output mismatch (-ResultSet +RowIter):\n%s", diff)
@@ -92,8 +88,8 @@ func TestExperimentalCsvBehavior(t *testing.T) {
 		if err := writeCsvFromResultSet(&bytes.Buffer{}, nil); err == nil {
 			t.Fatal("writeCsvFromResultSet(nil) expected error")
 		}
-		if err := writeCsvWithMetadata(&bytes.Buffer{}, nil, nil); err == nil {
-			t.Fatal("writeCsvWithMetadata(nil metadata) expected error")
+		if err := prepareCsvRowType(svwriter.NewCSVWriter(&bytes.Buffer{}), nil); err == nil {
+			t.Fatal("prepareCsvRowType(nil metadata) expected error")
 		}
 	})
 
@@ -146,6 +142,18 @@ func experimentalCsvViaSpanvalueWriter(out *bytes.Buffer, rs *sppb.ResultSet) er
 	csvWriter := svwriter.NewCSVWriter(out, svwriter.WithMetadata(rs.GetMetadata()))
 	for _, row := range rs.GetRows() {
 		if err := csvWriter.WriteStructValues(row.GetValues()); err != nil {
+			return err
+		}
+	}
+	return csvWriter.Flush()
+}
+
+// writeCsvFromPreparedRows exercises the WriteRow path when metadata is already known
+// (equivalent to RowIterator export after PrepareRowType).
+func writeCsvFromPreparedRows(w io.Writer, metadata *sppb.ResultSetMetadata, rows []*spanner.Row) error {
+	csvWriter := svwriter.NewCSVWriter(w, svwriter.WithMetadata(metadata))
+	for _, row := range rows {
+		if err := csvWriter.WriteRow(row); err != nil {
 			return err
 		}
 	}

--- a/csv_test.go
+++ b/csv_test.go
@@ -18,7 +18,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// TestExperimentalCsvSpanvalueContract ensures writeCsv stays aligned with
+// TestExperimentalCsvSpanvalueContract ensures writeCsvFromResultSet stays aligned with
 // spanvalue's DelimitedWriter (SimpleFormatConfig). When spanvalue is upgraded,
 // update golden files if the change is intentional:
 //
@@ -31,16 +31,55 @@ func TestExperimentalCsvSpanvalueContract(t *testing.T) {
 			t.Parallel()
 
 			var got, want bytes.Buffer
-			if err := writeCsv(&got, rs); err != nil {
-				t.Fatalf("writeCsv() error = %v", err)
+			if err := writeCsvFromResultSet(&got, rs); err != nil {
+				t.Fatalf("writeCsvFromResultSet() error = %v", err)
 			}
 			if err := experimentalCsvViaSpanvalueWriter(&want, rs); err != nil {
 				t.Fatalf("experimentalCsvViaSpanvalueWriter() error = %v", err)
 			}
 			if diff := cmp.Diff(want.String(), got.String()); diff != "" {
-				t.Fatalf("writeCsv() output mismatch (-spanvalue writer +writeCsv):\n%s", diff)
+				t.Fatalf("writeCsvFromResultSet() output mismatch (-spanvalue writer +writeCsvFromResultSet):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestExperimentalCsvRowIterPathMatchesResultSet checks that the production RowIterator
+// path (WriteRow) matches the ResultSet test helper (WriteStructValues).
+func TestExperimentalCsvRowIterPathMatchesResultSet(t *testing.T) {
+	t.Parallel()
+
+	rs := resultSet(
+		[]string{"id", "name"},
+		[]*sppb.Type{{Code: sppb.TypeCode_INT64}, {Code: sppb.TypeCode_STRING}},
+		[][]*structpb.Value{
+			{structpb.NewStringValue("1"), structpb.NewStringValue("alice")},
+			{structpb.NewStringValue("2"), structpb.NewStringValue("bob")},
+		},
+	)
+	row1, err := spanner.NewRow([]string{"id", "name"}, []interface{}{int64(1), "alice"})
+	if err != nil {
+		t.Fatalf("spanner.NewRow() error = %v", err)
+	}
+	row2, err := spanner.NewRow([]string{"id", "name"}, []interface{}{int64(2), "bob"})
+	if err != nil {
+		t.Fatalf("spanner.NewRow() error = %v", err)
+	}
+
+	var fromResultSet, fromRowIter bytes.Buffer
+	if err := writeCsvFromResultSet(&fromResultSet, rs); err != nil {
+		t.Fatalf("writeCsvFromResultSet() error = %v", err)
+	}
+	if err := writeCsvWithMetadata(&fromRowIter, rs.GetMetadata(), func(yield func(*spanner.Row, error) bool) {
+		if !yield(row1, nil) {
+			return
+		}
+		yield(row2, nil)
+	}); err != nil {
+		t.Fatalf("writeCsvWithMetadata() error = %v", err)
+	}
+	if diff := cmp.Diff(fromResultSet.String(), fromRowIter.String()); diff != "" {
+		t.Fatalf("RowIterator path output mismatch (-ResultSet +RowIter):\n%s", diff)
 	}
 }
 
@@ -50,8 +89,11 @@ func TestExperimentalCsvBehavior(t *testing.T) {
 
 	t.Run("invalid_metadata", func(t *testing.T) {
 		t.Parallel()
-		if err := writeCsv(&bytes.Buffer{}, nil); err == nil {
-			t.Fatal("writeCsv(nil) expected error")
+		if err := writeCsvFromResultSet(&bytes.Buffer{}, nil); err == nil {
+			t.Fatal("writeCsvFromResultSet(nil) expected error")
+		}
+		if err := writeCsvWithMetadata(&bytes.Buffer{}, nil, nil); err == nil {
+			t.Fatal("writeCsvWithMetadata(nil metadata) expected error")
 		}
 	})
 
@@ -62,8 +104,8 @@ func TestExperimentalCsvBehavior(t *testing.T) {
 			[]*sppb.Type{{Code: sppb.TypeCode_INT64}, {Code: sppb.TypeCode_STRING}},
 			[][]*structpb.Value{{structpb.NewStringValue("1")}},
 		)
-		if err := writeCsv(&bytes.Buffer{}, rs); err == nil {
-			t.Fatal("writeCsv() expected row value count mismatch error")
+		if err := writeCsvFromResultSet(&bytes.Buffer{}, rs); err == nil {
+			t.Fatal("writeCsvFromResultSet() expected row value count mismatch error")
 		}
 	})
 
@@ -75,8 +117,8 @@ func TestExperimentalCsvBehavior(t *testing.T) {
 			nil,
 		)
 		rs.Rows = []*structpb.ListValue{nil}
-		if err := writeCsv(&bytes.Buffer{}, rs); err == nil {
-			t.Fatal("writeCsv() expected error for nil row")
+		if err := writeCsvFromResultSet(&bytes.Buffer{}, rs); err == nil {
+			t.Fatal("writeCsvFromResultSet() expected error for nil row")
 		}
 	})
 }
@@ -92,32 +134,18 @@ func TestExperimentalCsvDumpFixtures(t *testing.T) {
 	}
 	for name, rs := range fixtures {
 		var buf bytes.Buffer
-		if err := writeCsv(&buf, rs); err != nil {
-			t.Fatalf("%s: writeCsv() error = %v", name, err)
+		if err := writeCsvFromResultSet(&buf, rs); err != nil {
+			t.Fatalf("%s: writeCsvFromResultSet() error = %v", name, err)
 		}
 		t.Logf("=== %s ===\n%s", name, buf.String())
 	}
 }
 
-// experimentalCsvViaSpanvalueWriter is the reference path writeCsv is expected to follow.
+// experimentalCsvViaSpanvalueWriter is the reference path for ResultSet-shaped fixtures.
 func experimentalCsvViaSpanvalueWriter(out *bytes.Buffer, rs *sppb.ResultSet) error {
 	csvWriter := svwriter.NewCSVWriter(out, svwriter.WithMetadata(rs.GetMetadata()))
-	fields := rs.GetMetadata().GetRowType().GetFields()
-
-	if len(rs.GetRows()) == 0 {
-		if err := csvWriter.WriteHeader(); err != nil {
-			return err
-		}
-		return csvWriter.Flush()
-	}
-
-	gcvs := make([]spanner.GenericColumnValue, len(fields))
 	for _, row := range rs.GetRows() {
-		values := row.GetValues()
-		for i, field := range fields {
-			gcvs[i] = spanner.GenericColumnValue{Type: field.GetType(), Value: values[i]}
-		}
-		if err := csvWriter.WriteGCVs(gcvs); err != nil {
+		if err := csvWriter.WriteStructValues(row.GetValues()); err != nil {
 			return err
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/apstndb/memebridge v0.6.0
 	github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10
 	github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb
-	github.com/apstndb/spanvalue v0.4.1-alpha.2
+	github.com/apstndb/spanvalue v0.4.1
 	github.com/cloudspannerecosystem/memefish v0.6.2
 	github.com/google/go-cmp v0.7.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/apstndb/memebridge v0.6.0
 	github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10
 	github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb
-	github.com/apstndb/spanvalue v0.4.0
+	github.com/apstndb/spanvalue v0.4.1-alpha.2
 	github.com/cloudspannerecosystem/memefish v0.6.2
 	github.com/google/go-cmp v0.7.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -674,8 +674,8 @@ github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb h1:wop6M8ZQWhV
 github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb/go.mod h1:H9relGptAtWqSNrJy+V1jiYPeBIk8KYh6lACV3VZrqU=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=
 github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
-github.com/apstndb/spanvalue v0.4.1-alpha.2 h1:P0McRPcM7XnVP5fVPGpPh1j4JvCHnZCujma538Y4wkw=
-github.com/apstndb/spanvalue v0.4.1-alpha.2/go.mod h1:xKnvCW0eC+EtZfICvyesMpr/PJTY8tXjcWR+i0x0dZw=
+github.com/apstndb/spanvalue v0.4.1 h1:5G4TzCb5KPovcx8dsmRu81dKOyKydMaJlWgJdomTutI=
+github.com/apstndb/spanvalue v0.4.1/go.mod h1:xKnvCW0eC+EtZfICvyesMpr/PJTY8tXjcWR+i0x0dZw=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=

--- a/go.sum
+++ b/go.sum
@@ -674,8 +674,8 @@ github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb h1:wop6M8ZQWhV
 github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb/go.mod h1:H9relGptAtWqSNrJy+V1jiYPeBIk8KYh6lACV3VZrqU=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=
 github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
-github.com/apstndb/spanvalue v0.4.0 h1:PJP4rv+AjBMVca98DOQI3xpsBiGJq9pT4LI6mfNkX/4=
-github.com/apstndb/spanvalue v0.4.0/go.mod h1:xKnvCW0eC+EtZfICvyesMpr/PJTY8tXjcWR+i0x0dZw=
+github.com/apstndb/spanvalue v0.4.1-alpha.2 h1:P0McRPcM7XnVP5fVPGpPh1j4JvCHnZCujma538Y4wkw=
+github.com/apstndb/spanvalue v0.4.1-alpha.2/go.mod h1:xKnvCW0eC+EtZfICvyesMpr/PJTY8tXjcWR+i0x0dZw=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=

--- a/main.go
+++ b/main.go
@@ -405,6 +405,9 @@ func writeCsvFromRowIter(writer io.Writer, rowIter *spanner.RowIterator, redactR
 	first := true
 	for {
 		row, err := rowIter.Next()
+		if err != nil && !errors.Is(err, iterator.Done) {
+			return err
+		}
 		if first {
 			first = false
 			if err := prepareCsvRowType(csvWriter, rowIter.Metadata); err != nil {
@@ -413,9 +416,6 @@ func writeCsvFromRowIter(writer io.Writer, rowIter *spanner.RowIterator, redactR
 		}
 		if errors.Is(err, iterator.Done) {
 			break
-		}
-		if err != nil {
-			return err
 		}
 		if err := csvWriter.WriteRow(row); err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -330,13 +330,13 @@ func _main() error {
 		return nil
 	}
 
+	if o.Format == "experimental_csv" {
+		return runAndWriteCsv(ctx, client, stmt, spanner.QueryOptions{Mode: &mode}, m, o.RedactRows)
+	}
+
 	rs, err := runInNewTransaction(ctx, client, stmt, spanner.QueryOptions{Mode: &mode}, m, o.RedactRows)
 	if err != nil {
 		return err
-	}
-
-	if o.Format == "experimental_csv" {
-		return writeCsv(os.Stdout, rs)
 	}
 
 	object, err := toProtojsonObject(rs)
@@ -352,14 +352,73 @@ func _main() error {
 	return printResult(enc, jqQuery.Run(object))
 }
 
-func writeCsv(writer io.Writer, rs *sppb.ResultSet) (writeErr error) {
-	if rs == nil || rs.GetMetadata() == nil || rs.GetMetadata().GetRowType() == nil {
+func runAndWriteCsv(ctx context.Context, client *spanner.Client, stmt spanner.Statement, opts spanner.QueryOptions, mode queryMode, redactRows bool) error {
+	switch mode := mode.(type) {
+	case readWrite:
+		_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
+			return writeCsvFromRowIter(os.Stdout, tx.QueryWithOptions(ctx, stmt, opts), redactRows)
+		})
+		return err
+	case single:
+		iter := client.Single().WithTimestampBound(mode.TimestampBound).QueryWithOptions(ctx, stmt, opts)
+		return writeCsvFromRowIter(os.Stdout, iter, redactRows)
+	case partitionedDML:
+		count, err := client.PartitionedUpdateWithOptions(ctx, stmt, opts)
+		if err != nil {
+			return err
+		}
+		return writeCsvFromResultSet(os.Stdout, &sppb.ResultSet{
+			Metadata: &sppb.ResultSetMetadata{RowType: &sppb.StructType{}},
+			Stats: &sppb.ResultSetStats{
+				RowCount: &sppb.ResultSetStats_RowCountLowerBound{RowCountLowerBound: count},
+			},
+		})
+	default:
+		panic(fmt.Sprintf("unknown mode: %d", mode))
+	}
+}
+
+// writeCsvFromRowIter streams query rows to CSV without materializing a ResultSet.
+func writeCsvFromRowIter(writer io.Writer, rowIter *spanner.RowIterator, redactRows bool) error {
+	defer rowIter.Stop()
+
+	if redactRows {
+		if err := skipRowIter(rowIter); err != nil {
+			return err
+		}
+		return writeCsvWithMetadata(writer, rowIter.Metadata, nil)
+	}
+
+	row, err := rowIter.Next()
+	if errors.Is(err, iterator.Done) {
+		return writeCsvWithMetadata(writer, rowIter.Metadata, nil)
+	}
+	if err != nil {
+		return err
+	}
+
+	return writeCsvWithMetadata(writer, rowIter.Metadata, prependRowSeq(row, rowIter))
+}
+
+func prependRowSeq(first *spanner.Row, rowIter *spanner.RowIterator) iter.Seq2[*spanner.Row, error] {
+	return func(yield func(*spanner.Row, error) bool) {
+		if !yield(first, nil) {
+			return
+		}
+		for row, err := range rowIterSeq(rowIter) {
+			if !yield(row, err) {
+				return
+			}
+		}
+	}
+}
+
+func writeCsvWithMetadata(writer io.Writer, metadata *sppb.ResultSetMetadata, rows iter.Seq2[*spanner.Row, error]) (writeErr error) {
+	if metadata == nil || metadata.GetRowType() == nil {
 		return errors.New("result set metadata is missing or invalid")
 	}
 
-	csvWriter := svwriter.NewCSVWriter(writer, svwriter.WithMetadata(rs.GetMetadata()))
-	fields := rs.GetMetadata().GetRowType().GetFields()
-
+	csvWriter := svwriter.NewCSVWriter(writer, svwriter.WithMetadata(metadata))
 	defer func() {
 		if err := csvWriter.Flush(); err != nil {
 			if writeErr == nil {
@@ -370,27 +429,47 @@ func writeCsv(writer io.Writer, rs *sppb.ResultSet) (writeErr error) {
 		}
 	}()
 
-	if len(rs.GetRows()) == 0 {
-		return csvWriter.WriteHeader()
+	for row, err := range rows {
+		if err != nil {
+			return err
+		}
+		if row == nil {
+			return fmt.Errorf("nil row in result set")
+		}
+		if err := csvWriter.WriteRow(row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeCsvFromResultSet writes CSV from an in-memory ResultSet. Used by unit tests
+// and partitioned DML (no RowIterator).
+func writeCsvFromResultSet(writer io.Writer, rs *sppb.ResultSet) (writeErr error) {
+	if rs == nil || rs.GetMetadata() == nil || rs.GetMetadata().GetRowType() == nil {
+		return errors.New("result set metadata is missing or invalid")
 	}
 
-	gcvs := make([]spanner.GenericColumnValue, len(fields))
+	csvWriter := svwriter.NewCSVWriter(writer, svwriter.WithMetadata(rs.GetMetadata()))
+	defer func() {
+		if err := csvWriter.Flush(); err != nil {
+			if writeErr == nil {
+				writeErr = err
+			} else {
+				writeErr = errors.Join(writeErr, err)
+			}
+		}
+	}()
+
 	for _, row := range rs.GetRows() {
 		if row == nil {
 			return fmt.Errorf("nil row in result set")
 		}
-		values := row.GetValues()
-		if len(values) != len(fields) {
-			return fmt.Errorf("row value count %d does not match metadata field count %d", len(values), len(fields))
-		}
-		for i, field := range fields {
-			gcvs[i] = spanner.GenericColumnValue{Type: field.GetType(), Value: values[i]}
-		}
-		if err := csvWriter.WriteGCVs(gcvs); err != nil {
+		if err := csvWriter.WriteStructValues(row.GetValues()); err != nil {
 			return err
 		}
 	}
-	return
+	return nil
 }
 
 func newClient(ctx context.Context, project, instance, database string, logGrpc bool, doTrace bool) (*spanner.Client, error) {

--- a/main.go
+++ b/main.go
@@ -379,88 +379,60 @@ func runAndWriteCsv(ctx context.Context, client *spanner.Client, stmt spanner.St
 }
 
 // writeCsvFromRowIter streams query rows to CSV without materializing a ResultSet.
+// It follows spanvalue v0.4.1 RowIterator guidance: PrepareRowType after the first Next
+// (including iterator.Done), WriteRow in the loop, return Flush (not defer Flush).
 func writeCsvFromRowIter(writer io.Writer, rowIter *spanner.RowIterator, redactRows bool) error {
 	defer rowIter.Stop()
+
+	csvWriter := svwriter.NewCSVWriter(writer)
 
 	if redactRows {
 		if err := skipRowIter(rowIter); err != nil {
 			return err
 		}
-		return writeCsvWithMetadata(writer, rowIter.Metadata, nil)
-	}
-
-	row, err := rowIter.Next()
-	if errors.Is(err, iterator.Done) {
-		return writeCsvWithMetadata(writer, rowIter.Metadata, nil)
-	}
-	if err != nil {
-		return err
-	}
-
-	return writeCsvWithMetadata(writer, rowIter.Metadata, prependRowSeq(row, rowIter))
-}
-
-func prependRowSeq(first *spanner.Row, rowIter *spanner.RowIterator) iter.Seq2[*spanner.Row, error] {
-	return func(yield func(*spanner.Row, error) bool) {
-		if !yield(first, nil) {
-			return
-		}
-		for row, err := range rowIterSeq(rowIter) {
-			if !yield(row, err) {
-				return
-			}
-		}
-	}
-}
-
-func writeCsvWithMetadata(writer io.Writer, metadata *sppb.ResultSetMetadata, rows iter.Seq2[*spanner.Row, error]) (writeErr error) {
-	if metadata == nil || metadata.GetRowType() == nil {
-		return errors.New("result set metadata is missing or invalid")
-	}
-
-	csvWriter := svwriter.NewCSVWriter(writer, svwriter.WithMetadata(metadata))
-	defer func() {
-		if err := csvWriter.Flush(); err != nil {
-			if writeErr == nil {
-				writeErr = err
-			} else {
-				writeErr = errors.Join(writeErr, err)
-			}
-		}
-	}()
-
-	for row, err := range rows {
-		if err != nil {
+		if err := prepareCsvRowType(csvWriter, rowIter.Metadata); err != nil {
 			return err
 		}
-		if row == nil {
-			return fmt.Errorf("nil row in result set")
+		return csvWriter.Flush()
+	}
+
+	first := true
+	for {
+		row, err := rowIter.Next()
+		if first {
+			first = false
+			if err := prepareCsvRowType(csvWriter, rowIter.Metadata); err != nil {
+				return err
+			}
+		}
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return err
 		}
 		if err := csvWriter.WriteRow(row); err != nil {
 			return err
 		}
 	}
-	return nil
+	return csvWriter.Flush()
+}
+
+func prepareCsvRowType(csvWriter *svwriter.DelimitedWriter, metadata *sppb.ResultSetMetadata) error {
+	if metadata == nil || metadata.GetRowType() == nil {
+		return errors.New("result set metadata is missing or invalid")
+	}
+	return csvWriter.PrepareRowType(metadata.GetRowType())
 }
 
 // writeCsvFromResultSet writes CSV from an in-memory ResultSet. Used by unit tests
-// and partitioned DML (no RowIterator).
-func writeCsvFromResultSet(writer io.Writer, rs *sppb.ResultSet) (writeErr error) {
+// and partitioned DML (no RowIterator). WithMetadata at construction is appropriate here.
+func writeCsvFromResultSet(writer io.Writer, rs *sppb.ResultSet) error {
 	if rs == nil || rs.GetMetadata() == nil || rs.GetMetadata().GetRowType() == nil {
 		return errors.New("result set metadata is missing or invalid")
 	}
 
 	csvWriter := svwriter.NewCSVWriter(writer, svwriter.WithMetadata(rs.GetMetadata()))
-	defer func() {
-		if err := csvWriter.Flush(); err != nil {
-			if writeErr == nil {
-				writeErr = err
-			} else {
-				writeErr = errors.Join(writeErr, err)
-			}
-		}
-	}()
-
 	for _, row := range rs.GetRows() {
 		if row == nil {
 			return fmt.Errorf("nil row in result set")
@@ -469,7 +441,7 @@ func writeCsvFromResultSet(writer io.Writer, rs *sppb.ResultSet) (writeErr error
 			return err
 		}
 	}
-	return nil
+	return csvWriter.Flush()
 }
 
 func newClient(ctx context.Context, project, instance, database string, logGrpc bool, doTrace bool) (*spanner.Client, error) {

--- a/main.go
+++ b/main.go
@@ -196,7 +196,7 @@ func runInNewTransaction(ctx context.Context, client *spanner.Client, stmt spann
 			},
 		}, err
 	default:
-		panic(fmt.Sprintf("unknown mode: %d", mode))
+		panic(fmt.Sprintf("unknown mode: %T", mode))
 	}
 }
 
@@ -355,9 +355,15 @@ func _main() error {
 func runAndWriteCsv(ctx context.Context, client *spanner.Client, stmt spanner.Statement, opts spanner.QueryOptions, mode queryMode, redactRows bool) error {
 	switch mode := mode.(type) {
 	case readWrite:
+		var buf bytes.Buffer
 		_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
-			return writeCsvFromRowIter(os.Stdout, tx.QueryWithOptions(ctx, stmt, opts), redactRows)
+			buf.Reset()
+			return writeCsvFromRowIter(&buf, tx.QueryWithOptions(ctx, stmt, opts), redactRows)
 		})
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(os.Stdout, &buf)
 		return err
 	case single:
 		iter := client.Single().WithTimestampBound(mode.TimestampBound).QueryWithOptions(ctx, stmt, opts)
@@ -374,7 +380,7 @@ func runAndWriteCsv(ctx context.Context, client *spanner.Client, stmt spanner.St
 			},
 		})
 	default:
-		panic(fmt.Sprintf("unknown mode: %d", mode))
+		panic(fmt.Sprintf("unknown mode: %T", mode))
 	}
 }
 


### PR DESCRIPTION
## Summary

- **CSV path streams from `RowIterator`** without materializing a full `ResultSet`; uses spanvalue **`WriteRow`** per row.
- **spanvalue [v0.4.1](https://github.com/apstndb/spanvalue/releases/tag/v0.4.1)** (source-compatible with v0.4.0): follows upstream RowIterator guidance — `PrepareRowType(iter.Metadata.GetRowType())` on the first `Next` (including `iterator.Done`), `return w.Flush()` (not `defer Flush()`). Do **not** pass `iter.Metadata` to `WithMetadata` at writer construction.
- **JSON/YAML + jq** unchanged: still builds `ResultSet` for gojq.
- **In-memory / partitioned DML**: `WithMetadata` + `WriteStructValues` (metadata already available).

## v0.4.1 highlights (relevant)

| Case | Behavior |
|------|----------|
| Zero-row `SELECT` | Header on `Flush` after `PrepareRowType` |
| Zero-column row type (partitioned DML) | Empty output on `Flush` |
| `WriteStructValues` | For `[]*structpb.Value` when types are registered |

## Test plan

- [x] `go test ./...`
- [x] `TestExperimentalCsvGolden`
- [x] `TestExperimentalCsvRowIterPathMatchesResultSet`
- [x] `TestExperimentalCsvSpanvalueContract`