### PR TITLE
deps: bump github.com/apstndb/spanvalue from v0.7.5 to v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/apstndb/memebridge v0.6.0
 	github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10
 	github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb
-	github.com/apstndb/spanvalue v0.7.5
+	github.com/apstndb/spanvalue v0.8.0
 	github.com/cloudspannerecosystem/memefish v0.6.2
 	github.com/google/go-cmp v0.7.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -674,8 +674,8 @@ github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb h1:wop6M8ZQWhV
 github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb/go.mod h1:H9relGptAtWqSNrJy+V1jiYPeBIk8KYh6lACV3VZrqU=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=
 github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
-github.com/apstndb/spanvalue v0.7.5 h1:qxx/dJ2BnNwS8rT347mKrwDbC2I9pckv9rC91+5fXuU=
-github.com/apstndb/spanvalue v0.7.5/go.mod h1:bqVJYydQf+D0Tux1LtyRlREPVwrVYNG+1usZJ489GTA=
+github.com/apstndb/spanvalue v0.8.0 h1:wLHl/0m5C6PvRwJOJoz1nRL4qSpS17eS1tW3Pjzcvo8=
+github.com/apstndb/spanvalue v0.8.0/go.mod h1:bqVJYydQf+D0Tux1LtyRlREPVwrVYNG+1usZJ489GTA=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=


### PR DESCRIPTION
## Summary

- Bump `github.com/apstndb/spanvalue` from v0.7.5 to v0.8.0 ([release notes](https://github.com/apstndb/spanvalue/releases/tag/v0.8.0)).
- v0.8.0 is a breaking release upstream, but pre-release verification confirmed execspansql needs **no code changes**: it only uses the `spanvalue/writer` CSV path with default presets and none of the removed APIs. This PR touches `go.mod` / `go.sum` only.
- The existing spanvalue contract/golden CSV tests (`csv_test.go`, `csv_fixtures_test.go`) pass unmodified.

## Test plan

- [x] `go get github.com/apstndb/spanvalue@v0.8.0 && go mod tidy`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages pass; spanvalue contract/golden CSV tests unmodified
- [x] `go test -v -run TestWithCloudSpannerEmulator .` — testcontainers Cloud Spanner emulator integration test ran with Docker and passed (including `experimental_csv_writeCsvFromRowIter` subtests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
