### PR TITLE
Use spaniter ResultSetStats helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/apstndb/gsqlsep v0.0.0-20240823174243-432be37d515a
 	github.com/apstndb/memebridge v0.6.0
 	github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10
-	github.com/apstndb/spaniter v0.1.1-alpha.2
+	github.com/apstndb/spaniter v0.1.1-alpha.3
 	github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb
 	github.com/apstndb/spanvalue v0.8.0
 	github.com/cloudspannerecosystem/memefish v0.6.2

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/apstndb/gsqlsep v0.0.0-20240823174243-432be37d515a
 	github.com/apstndb/memebridge v0.6.0
 	github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10
-	github.com/apstndb/spaniter v0.1.0
+	github.com/apstndb/spaniter v0.1.1-alpha.2
 	github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb
 	github.com/apstndb/spanvalue v0.8.0
 	github.com/cloudspannerecosystem/memefish v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -670,8 +670,8 @@ github.com/apstndb/memebridge v0.6.0 h1:45uu/RFF63u5vJ+d8HT4PvOfotm1cV4eEveWFwGv
 github.com/apstndb/memebridge v0.6.0/go.mod h1:E/HVP4iaSgiPXMIQTPT1u1uKkjmRtRECkVKE2TrF3bc=
 github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10 h1:Ea5al1Su3ZNw2HltOc1fjLADUp16jV9ns03D9Xvpep4=
 github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10/go.mod h1:JtIpejiunpnBufWCwhEun+ayfd0JWnPp9kqbcNJkU+E=
-github.com/apstndb/spaniter v0.1.0 h1:OpTpePq0bN/EWS1mIXAk0lfQ98PAI4xRcBQ4pd9Ijk0=
-github.com/apstndb/spaniter v0.1.0/go.mod h1:vl6zVOnA2m35fAeF1WsGD7AuaWUK5aCVG6aS/35njFE=
+github.com/apstndb/spaniter v0.1.1-alpha.2 h1:hqKhWqgevQNwpsjGrtSiyUMBTkLRh18VemOSY5Zi5ys=
+github.com/apstndb/spaniter v0.1.1-alpha.2/go.mod h1:aBSHcHIqgAZXCxFdi734R/wAQUIuCQ6WZ+CjOCxARIM=
 github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb h1:wop6M8ZQWhVLYtiBKXvkNd6TFUSpiGya86Az57KiTl0=
 github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb/go.mod h1:H9relGptAtWqSNrJy+V1jiYPeBIk8KYh6lACV3VZrqU=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=

--- a/go.sum
+++ b/go.sum
@@ -670,8 +670,8 @@ github.com/apstndb/memebridge v0.6.0 h1:45uu/RFF63u5vJ+d8HT4PvOfotm1cV4eEveWFwGv
 github.com/apstndb/memebridge v0.6.0/go.mod h1:E/HVP4iaSgiPXMIQTPT1u1uKkjmRtRECkVKE2TrF3bc=
 github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10 h1:Ea5al1Su3ZNw2HltOc1fjLADUp16jV9ns03D9Xvpep4=
 github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10/go.mod h1:JtIpejiunpnBufWCwhEun+ayfd0JWnPp9kqbcNJkU+E=
-github.com/apstndb/spaniter v0.1.1-alpha.2 h1:hqKhWqgevQNwpsjGrtSiyUMBTkLRh18VemOSY5Zi5ys=
-github.com/apstndb/spaniter v0.1.1-alpha.2/go.mod h1:aBSHcHIqgAZXCxFdi734R/wAQUIuCQ6WZ+CjOCxARIM=
+github.com/apstndb/spaniter v0.1.1-alpha.3 h1:CHQNt0whNYUYfqSZZfh5VYGED6ny+FrJwNpSYwzVzRU=
+github.com/apstndb/spaniter v0.1.1-alpha.3/go.mod h1:aBSHcHIqgAZXCxFdi734R/wAQUIuCQ6WZ+CjOCxARIM=
 github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb h1:wop6M8ZQWhVLYtiBKXvkNd6TFUSpiGya86Az57KiTl0=
 github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb/go.mod h1:H9relGptAtWqSNrJy+V1jiYPeBIk8KYh6lACV3VZrqU=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=

--- a/jqresult/jqresult_test.go
+++ b/jqresult/jqresult_test.go
@@ -74,6 +74,15 @@ func TestNormalizeForEncodeLeafSlice(t *testing.T) {
 	}
 }
 
+func TestBuildResultSetNilRowIterator(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildResultSet(nil, nil)
+	if err == nil {
+		t.Fatal("error = nil, want nil row iterator error")
+	}
+}
+
 func TestLazyRowsAfterStatsDrain(t *testing.T) {
 	t.Parallel()
 	l := &Lazy{

--- a/jqresult/protojson.go
+++ b/jqresult/protojson.go
@@ -6,6 +6,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spaniter"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -61,37 +62,30 @@ func ResultSetMap(rs *sppb.ResultSet) (map[string]any, error) {
 
 // BuildResultSet constructs ResultSet stats from a consumed row iterator.
 func BuildResultSet(rows []*structpb.ListValue, rowIter *spanner.RowIterator) (*sppb.ResultSet, error) {
-	return BuildResultSetFromParts(rows, rowIter.Metadata, rowIter.QueryPlan, rowIter.QueryStats, rowIter.RowCount)
+	return BuildResultSetFromParts(rows, rowIter.Metadata, spaniter.Stats{
+		QueryPlan:  rowIter.QueryPlan,
+		QueryStats: rowIter.QueryStats,
+		RowCount:   rowIter.RowCount,
+	})
 }
 
 // BuildResultSetFromParts constructs a ResultSet from materialized rows and
 // consumed iterator metadata. rows may be nil when row values are intentionally
 // redacted; metadata and stats are still preserved from the drained iterator.
-func BuildResultSetFromParts(rows []*structpb.ListValue, metadata *sppb.ResultSetMetadata, queryPlan *sppb.QueryPlan, queryStatsMap map[string]any, rowCount int64) (*sppb.ResultSet, error) {
+func BuildResultSetFromParts(rows []*structpb.ListValue, metadata *sppb.ResultSetMetadata, stats spaniter.Stats) (*sppb.ResultSet, error) {
 	out := &sppb.ResultSet{
 		Rows:     rows,
 		Metadata: metadata,
 	}
 
-	var queryStats *structpb.Struct
-	if queryStatsMap != nil {
-		qs, err := structpb.NewStruct(queryStatsMap)
-		if err != nil {
-			return nil, err
-		}
-		queryStats = qs
-	}
-
-	if queryPlan == nil && queryStats == nil && rowCount == 0 {
+	if !stats.HasResultSetStats() {
 		return out, nil
 	}
 
-	out.Stats = &sppb.ResultSetStats{
-		QueryPlan:  queryPlan,
-		QueryStats: queryStats,
+	resultStats, err := stats.ResultSetStats()
+	if err != nil {
+		return nil, err
 	}
-	if rowCount != 0 {
-		out.Stats.RowCount = &sppb.ResultSetStats_RowCountExact{RowCountExact: rowCount}
-	}
+	out.Stats = resultStats
 	return out, nil
 }

--- a/jqresult/protojson.go
+++ b/jqresult/protojson.go
@@ -3,6 +3,7 @@ package jqresult
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
@@ -62,6 +63,9 @@ func ResultSetMap(rs *sppb.ResultSet) (map[string]any, error) {
 
 // BuildResultSet constructs ResultSet stats from a consumed row iterator.
 func BuildResultSet(rows []*structpb.ListValue, rowIter *spanner.RowIterator) (*sppb.ResultSet, error) {
+	if rowIter == nil {
+		return nil, errors.New("nil row iterator")
+	}
 	return BuildResultSetFromParts(rows, rowIter.Metadata, spaniter.Stats{
 		QueryPlan:  rowIter.QueryPlan,
 		QueryStats: rowIter.QueryStats,

--- a/jqresult/protojson.go
+++ b/jqresult/protojson.go
@@ -78,7 +78,7 @@ func BuildResultSetFromParts(rows []*structpb.ListValue, metadata *sppb.ResultSe
 		Metadata: metadata,
 	}
 
-	if !stats.HasResultSetStats() {
+	if stats.IsZero() {
 		return out, nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -572,7 +572,7 @@ func consumeRowIterIntoResultSet(rowIter *spanner.RowIterator, redactRows bool) 
 		if err != nil {
 			return nil, err
 		}
-		return jqresult.BuildResultSetFromParts(nil, result.Metadata, result.Stats.QueryPlan, result.Stats.QueryStats, result.Stats.RowCount)
+		return jqresult.BuildResultSetFromParts(nil, result.Metadata, result.Stats)
 	}
 
 	var result spaniter.RowIteratorResult
@@ -582,7 +582,7 @@ func consumeRowIterIntoResultSet(rowIter *spanner.RowIterator, redactRows bool) 
 	if err != nil {
 		return nil, err
 	}
-	return jqresult.BuildResultSetFromParts(rows, result.Metadata, result.Stats.QueryPlan, result.Stats.QueryStats, result.Stats.RowCount)
+	return jqresult.BuildResultSetFromParts(rows, result.Metadata, result.Stats)
 }
 
 func rowToListValue(r *spanner.Row) *structpb.ListValue {


### PR DESCRIPTION
## Summary

- Update `spaniter` to `v0.1.1-alpha.3`.
- Use `spaniter.Stats` as the boundary when rebuilding `*sppb.ResultSet` for jq inputs.
- Replace local `ResultSetStats` construction and empty-stats checks with `Stats.ResultSetStats` and `Stats.IsZero`.

## Context

This validates the downstream use case that motivated the new spaniter helpers: `execspansql` already drains/consumes `*spanner.RowIterator` through spaniter, then needs to expose the captured lifecycle data as a protobuf `ResultSet`.

## Tests

- `go test ./...`
- `make test`
