### PR TITLE
Refactor jq/result paths for spaniter v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,3 +120,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250728155136-f173205681a0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250728155136-f173205681a0 // indirect
 )
+
+replace github.com/apstndb/spaniter => ../spaniter

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/apstndb/gsqlsep v0.0.0-20240823174243-432be37d515a
 	github.com/apstndb/memebridge v0.6.0
 	github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10
-	github.com/apstndb/spaniter v0.2.0
+	github.com/apstndb/spaniter v0.3.0
 	github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb
 	github.com/apstndb/spanvalue v0.8.0
 	github.com/cloudspannerecosystem/memefish v0.6.2
@@ -120,5 +120,3 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250728155136-f173205681a0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250728155136-f173205681a0 // indirect
 )
-
-replace github.com/apstndb/spaniter => ../spaniter

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/apstndb/gsqlsep v0.0.0-20240823174243-432be37d515a
 	github.com/apstndb/memebridge v0.6.0
 	github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10
-	github.com/apstndb/spaniter v0.1.1-alpha.3
+	github.com/apstndb/spaniter v0.2.0
 	github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb
 	github.com/apstndb/spanvalue v0.8.0
 	github.com/cloudspannerecosystem/memefish v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -670,8 +670,8 @@ github.com/apstndb/memebridge v0.6.0 h1:45uu/RFF63u5vJ+d8HT4PvOfotm1cV4eEveWFwGv
 github.com/apstndb/memebridge v0.6.0/go.mod h1:E/HVP4iaSgiPXMIQTPT1u1uKkjmRtRECkVKE2TrF3bc=
 github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10 h1:Ea5al1Su3ZNw2HltOc1fjLADUp16jV9ns03D9Xvpep4=
 github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10/go.mod h1:JtIpejiunpnBufWCwhEun+ayfd0JWnPp9kqbcNJkU+E=
-github.com/apstndb/spaniter v0.1.1-alpha.3 h1:CHQNt0whNYUYfqSZZfh5VYGED6ny+FrJwNpSYwzVzRU=
-github.com/apstndb/spaniter v0.1.1-alpha.3/go.mod h1:aBSHcHIqgAZXCxFdi734R/wAQUIuCQ6WZ+CjOCxARIM=
+github.com/apstndb/spaniter v0.2.0 h1:n3uS2DhfJAgKUu8e+/SgLbhysg4yw/Va9OK/RdRAy+E=
+github.com/apstndb/spaniter v0.2.0/go.mod h1:aBSHcHIqgAZXCxFdi734R/wAQUIuCQ6WZ+CjOCxARIM=
 github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb h1:wop6M8ZQWhVLYtiBKXvkNd6TFUSpiGya86Az57KiTl0=
 github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb/go.mod h1:H9relGptAtWqSNrJy+V1jiYPeBIk8KYh6lACV3VZrqU=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=

--- a/go.sum
+++ b/go.sum
@@ -670,6 +670,8 @@ github.com/apstndb/memebridge v0.6.0 h1:45uu/RFF63u5vJ+d8HT4PvOfotm1cV4eEveWFwGv
 github.com/apstndb/memebridge v0.6.0/go.mod h1:E/HVP4iaSgiPXMIQTPT1u1uKkjmRtRECkVKE2TrF3bc=
 github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10 h1:Ea5al1Su3ZNw2HltOc1fjLADUp16jV9ns03D9Xvpep4=
 github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10/go.mod h1:JtIpejiunpnBufWCwhEun+ayfd0JWnPp9kqbcNJkU+E=
+github.com/apstndb/spaniter v0.3.0 h1:b0zXMONClGRfvWf7ciwsIYVso9qkhqFdjH0+PqOnQGI=
+github.com/apstndb/spaniter v0.3.0/go.mod h1:aBSHcHIqgAZXCxFdi734R/wAQUIuCQ6WZ+CjOCxARIM=
 github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb h1:wop6M8ZQWhVLYtiBKXvkNd6TFUSpiGya86Az57KiTl0=
 github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb/go.mod h1:H9relGptAtWqSNrJy+V1jiYPeBIk8KYh6lACV3VZrqU=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=

--- a/go.sum
+++ b/go.sum
@@ -670,8 +670,6 @@ github.com/apstndb/memebridge v0.6.0 h1:45uu/RFF63u5vJ+d8HT4PvOfotm1cV4eEveWFwGv
 github.com/apstndb/memebridge v0.6.0/go.mod h1:E/HVP4iaSgiPXMIQTPT1u1uKkjmRtRECkVKE2TrF3bc=
 github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10 h1:Ea5al1Su3ZNw2HltOc1fjLADUp16jV9ns03D9Xvpep4=
 github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10/go.mod h1:JtIpejiunpnBufWCwhEun+ayfd0JWnPp9kqbcNJkU+E=
-github.com/apstndb/spaniter v0.2.0 h1:n3uS2DhfJAgKUu8e+/SgLbhysg4yw/Va9OK/RdRAy+E=
-github.com/apstndb/spaniter v0.2.0/go.mod h1:aBSHcHIqgAZXCxFdi734R/wAQUIuCQ6WZ+CjOCxARIM=
 github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb h1:wop6M8ZQWhVLYtiBKXvkNd6TFUSpiGya86Az57KiTl0=
 github.com/apstndb/spannerotel v0.0.0-20220113012943-45b1c9cc5afb/go.mod h1:H9relGptAtWqSNrJy+V1jiYPeBIk8KYh6lACV3VZrqU=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=

--- a/integration_test.go
+++ b/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/csv"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -28,6 +29,38 @@ var ddl string
 
 //go:embed testdata/dml.sql
 var dml string
+
+func runLazyReadWriteDML(t *testing.T, client *spanner.Client, ctx context.Context, sql, filter string) []any {
+	t.Helper()
+
+	var out []any
+	_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
+		rowIter := tx.QueryWithOptions(ctx, spanner.Statement{SQL: sql}, spanner.QueryOptions{})
+		code, err := jqresult.Compile(filter, jqresult.InputLazy)
+		if err != nil {
+			return err
+		}
+		iter, cleanup, err := jqresult.Execute(code, jqresult.InputLazy, rowIter, nil, false, true, true)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		for {
+			v, ok := iter.Next()
+			if !ok {
+				return nil
+			}
+			if err, isErr := v.(error); isErr {
+				return err
+			}
+			out = append(out, v)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
 
 func TestWithCloudSpannerEmulator(t *testing.T) {
 	ctx := context.Background()
@@ -306,7 +339,7 @@ func TestWithCloudSpannerEmulator(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			iter, cleanup, err := jqresult.Execute(code, jqresult.InputLazy, rowIter, nil, redact, false)
+			iter, cleanup, err := jqresult.Execute(code, jqresult.InputLazy, rowIter, nil, redact, false, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -404,6 +437,91 @@ func TestWithCloudSpannerEmulator(t *testing.T) {
 		redactedRows := runLazy(t, ".rows[]", true, sppb.ExecuteSqlRequest_NORMAL.Enum())
 		if len(redactedRows) != 0 {
 			t.Fatalf("redacted .rows[]: got %d values, want 0", len(redactedRows))
+		}
+	})
+
+	t.Run("lazy jq readWrite DML executes when filter ignores input", func(t *testing.T) {
+		const want = "Revised"
+		_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
+			_, err := tx.Update(ctx, spanner.Statement{
+				SQL:    "UPDATE Singers SET FirstName=@name WHERE SingerId=1",
+				Params: map[string]any{"name": "Before"},
+			})
+			return err
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
+			rowIter := tx.QueryWithOptions(ctx, spanner.Statement{
+				SQL:    "UPDATE Singers SET FirstName=@name WHERE SingerId=1",
+				Params: map[string]any{"name": want},
+			}, spanner.QueryOptions{})
+			code, err := jqresult.Compile("true", jqresult.InputLazy)
+			if err != nil {
+				return err
+			}
+			iter, cleanup, err := jqresult.Execute(code, jqresult.InputLazy, rowIter, nil, false, true, true)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			for {
+				_, ok := iter.Next()
+				if !ok {
+					return nil
+				}
+			}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		row, err := client.Single().ReadRow(ctx, "Singers", spanner.Key{1}, []string{"FirstName"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got string
+		if err := row.Column(0, &got); err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
+			t.Fatalf("FirstName = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("lazy jq readWrite DML zero rows preserves rowCountExact", func(t *testing.T) {
+		statsOut := runLazyReadWriteDML(t, client, ctx,
+			"UPDATE Singers SET FirstName=FirstName WHERE SingerId=-1",
+			".stats.rowCountExact",
+		)
+		if len(statsOut) != 1 || statsOut[0] != "0" {
+			t.Fatalf("rowCountExact: got %v", statsOut)
+		}
+	})
+
+	t.Run("PLAN DML omits fabricated row count", func(t *testing.T) {
+		_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
+			rowIter := tx.QueryWithOptions(ctx, spanner.Statement{
+				SQL: "UPDATE Singers SET FirstName=FirstName WHERE SingerId=1",
+			}, spanner.QueryOptions{Mode: sppb.ExecuteSqlRequest_PLAN.Enum()})
+			rs, err := resultset.Materialize(rowIter, false, false)
+			if err != nil {
+				return err
+			}
+			if rs.Stats != nil {
+				if _, ok := rs.Stats.GetRowCount().(*sppb.ResultSetStats_RowCountExact); ok {
+					return fmt.Errorf("PLAN DML stats must not include rowCountExact: %v", rs.Stats)
+				}
+			}
+			if rs.Metadata == nil || rs.Metadata.GetRowType() == nil {
+				return fmt.Errorf("PLAN DML metadata missing: %#v", rs.Metadata)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
 		}
 	})
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/apstndb/execspansql/jqresult"
 	"github.com/apstndb/execspansql/params"
+	"github.com/apstndb/execspansql/resultset"
 )
 
 //go:embed testdata/ddl.sql
@@ -412,7 +413,7 @@ func TestWithCloudSpannerEmulator(t *testing.T) {
 			spanner.QueryOptions{Mode: sppb.ExecuteSqlRequest_PROFILE.Enum()},
 		)
 
-		rs, err := consumeRowIterIntoResultSet(rowIter, true)
+		rs, err := resultset.Materialize(rowIter, true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/integration_test.go
+++ b/integration_test.go
@@ -306,7 +306,7 @@ func TestWithCloudSpannerEmulator(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			iter, cleanup, err := jqresult.Execute(code, jqresult.InputLazy, rowIter, nil, redact)
+			iter, cleanup, err := jqresult.Execute(code, jqresult.InputLazy, rowIter, nil, redact, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -413,7 +413,7 @@ func TestWithCloudSpannerEmulator(t *testing.T) {
 			spanner.QueryOptions{Mode: sppb.ExecuteSqlRequest_PROFILE.Enum()},
 		)
 
-		rs, err := resultset.Materialize(rowIter, true)
+		rs, err := resultset.Materialize(rowIter, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/integration_test.go
+++ b/integration_test.go
@@ -35,6 +35,7 @@ func runEagerReadWriteDML(t *testing.T, client *spanner.Client, ctx context.Cont
 
 	var out []any
 	_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
+		out = nil
 		rowIter := tx.QueryWithOptions(ctx, spanner.Statement{SQL: sql}, spanner.QueryOptions{})
 		rs, err := resultset.Materialize(rowIter, false, spaniter.WithStatsEncoding(spaniter.StatsEncodingDMLExact))
 		if err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -36,7 +36,7 @@ func runEagerReadWriteDML(t *testing.T, client *spanner.Client, ctx context.Cont
 	var out []any
 	_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
 		rowIter := tx.QueryWithOptions(ctx, spanner.Statement{SQL: sql}, spanner.QueryOptions{})
-		rs, err := resultset.Materialize(rowIter, false, true)
+		rs, err := resultset.Materialize(rowIter, false, spaniter.WithStatsEncoding(spaniter.StatsEncodingDMLExact))
 		if err != nil {
 			return err
 		}
@@ -462,7 +462,7 @@ func TestWithCloudSpannerEmulator(t *testing.T) {
 				SQL:    "UPDATE Singers SET FirstName=@name WHERE SingerId=1",
 				Params: map[string]any{"name": want},
 			}, spanner.QueryOptions{})
-			rs, err := resultset.Materialize(rowIter, false, true)
+			rs, err := resultset.Materialize(rowIter, false, spaniter.WithStatsEncoding(spaniter.StatsEncodingDMLExact))
 			if err != nil {
 				return err
 			}
@@ -514,7 +514,7 @@ func TestWithCloudSpannerEmulator(t *testing.T) {
 			rowIter := tx.QueryWithOptions(ctx, spanner.Statement{
 				SQL: "UPDATE Singers SET FirstName=FirstName WHERE SingerId=1",
 			}, spanner.QueryOptions{Mode: sppb.ExecuteSqlRequest_PLAN.Enum()})
-			rs, err := resultset.Materialize(rowIter, false, false)
+			rs, err := resultset.Materialize(rowIter, false)
 			if err != nil {
 				return err
 			}
@@ -539,7 +539,7 @@ func TestWithCloudSpannerEmulator(t *testing.T) {
 			spanner.QueryOptions{Mode: sppb.ExecuteSqlRequest_PROFILE.Enum()},
 		)
 
-		rs, err := resultset.Materialize(rowIter, true, false)
+		rs, err := resultset.Materialize(rowIter, true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/integration_test.go
+++ b/integration_test.go
@@ -30,17 +30,21 @@ var ddl string
 //go:embed testdata/dml.sql
 var dml string
 
-func runLazyReadWriteDML(t *testing.T, client *spanner.Client, ctx context.Context, sql, filter string) []any {
+func runEagerReadWriteDML(t *testing.T, client *spanner.Client, ctx context.Context, sql, filter string) []any {
 	t.Helper()
 
 	var out []any
 	_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
 		rowIter := tx.QueryWithOptions(ctx, spanner.Statement{SQL: sql}, spanner.QueryOptions{})
-		code, err := jqresult.Compile(filter, jqresult.InputLazy)
+		rs, err := resultset.Materialize(rowIter, false, true)
 		if err != nil {
 			return err
 		}
-		iter, cleanup, err := jqresult.Execute(code, jqresult.InputLazy, rowIter, nil, false, true, true)
+		code, err := jqresult.Compile(filter, jqresult.InputEager)
+		if err != nil {
+			return err
+		}
+		iter, cleanup, err := jqresult.Execute(code, jqresult.InputEager, nil, rs, false)
 		if err != nil {
 			return err
 		}
@@ -339,7 +343,7 @@ func TestWithCloudSpannerEmulator(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			iter, cleanup, err := jqresult.Execute(code, jqresult.InputLazy, rowIter, nil, redact, false, false)
+			iter, cleanup, err := jqresult.Execute(code, jqresult.InputLazy, rowIter, nil, redact)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -440,7 +444,7 @@ func TestWithCloudSpannerEmulator(t *testing.T) {
 		}
 	})
 
-	t.Run("lazy jq readWrite DML executes when filter ignores input", func(t *testing.T) {
+	t.Run("readWrite DML uses eager jq when filter ignores input", func(t *testing.T) {
 		const want = "Revised"
 		_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
 			_, err := tx.Update(ctx, spanner.Statement{
@@ -458,11 +462,15 @@ func TestWithCloudSpannerEmulator(t *testing.T) {
 				SQL:    "UPDATE Singers SET FirstName=@name WHERE SingerId=1",
 				Params: map[string]any{"name": want},
 			}, spanner.QueryOptions{})
-			code, err := jqresult.Compile("true", jqresult.InputLazy)
+			rs, err := resultset.Materialize(rowIter, false, true)
 			if err != nil {
 				return err
 			}
-			iter, cleanup, err := jqresult.Execute(code, jqresult.InputLazy, rowIter, nil, false, true, true)
+			code, err := jqresult.Compile("true", jqresult.InputEager)
+			if err != nil {
+				return err
+			}
+			iter, cleanup, err := jqresult.Execute(code, jqresult.InputEager, nil, rs, false)
 			if err != nil {
 				return err
 			}
@@ -491,8 +499,8 @@ func TestWithCloudSpannerEmulator(t *testing.T) {
 		}
 	})
 
-	t.Run("lazy jq readWrite DML zero rows preserves rowCountExact", func(t *testing.T) {
-		statsOut := runLazyReadWriteDML(t, client, ctx,
+	t.Run("readWrite DML zero rows preserves rowCountExact", func(t *testing.T) {
+		statsOut := runEagerReadWriteDML(t, client, ctx,
 			"UPDATE Singers SET FirstName=FirstName WHERE SingerId=-1",
 			".stats.rowCountExact",
 		)

--- a/jqresult/jqresult_test.go
+++ b/jqresult/jqresult_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"cloud.google.com/go/spanner"
 	"github.com/apstndb/spaniter"
 	"github.com/wader/gojq"
 )
@@ -111,6 +112,35 @@ func TestLazyStopDoesNotDrain(t *testing.T) {
 	l.Stop()
 	if l.drained {
 		t.Fatal("Stop() must not drain rows")
+	}
+}
+
+func TestLazyCompleteOnStopDrains(t *testing.T) {
+	t.Parallel()
+
+	var pulls int
+	r := &RowIter{
+		redact:    true,
+		seqActive: true,
+		stopSeq:   func() {},
+		pull: func() (*spanner.Row, error, bool) {
+			pulls++
+			if pulls <= 2 {
+				return &spanner.Row{}, nil, true
+			}
+			return nil, nil, false
+		},
+	}
+	l := &Lazy{
+		completeOnStop: true,
+		rows:           r,
+	}
+	l.Stop()
+	if pulls != 3 {
+		t.Fatalf("Stop() pulled %d rows, want 3", pulls)
+	}
+	if !l.drained {
+		t.Fatal("Stop() with completeOnStop must drain")
 	}
 }
 

--- a/jqresult/jqresult_test.go
+++ b/jqresult/jqresult_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spaniter"
 	"github.com/wader/gojq"
 )
 
@@ -74,15 +74,6 @@ func TestNormalizeForEncodeLeafSlice(t *testing.T) {
 	}
 }
 
-func TestBuildResultSetNilRowIterator(t *testing.T) {
-	t.Parallel()
-
-	_, err := BuildResultSet(nil, nil)
-	if err == nil {
-		t.Fatal("error = nil, want nil row iterator error")
-	}
-}
-
 func TestLazyRowsAfterStatsDrain(t *testing.T) {
 	t.Parallel()
 	l := &Lazy{
@@ -128,7 +119,7 @@ func TestDrainAppendsStreamedRows(t *testing.T) {
 	l := &Lazy{
 		materializedRows: []any{[]any{int64(1)}},
 		rows:             &RowIter{stopped: true},
-		statsFn: func(*spanner.RowIterator) (map[string]any, error) {
+		encodeStats: func(spaniter.Stats) (map[string]any, error) {
 			return map[string]any{"ok": true}, nil
 		},
 	}

--- a/jqresult/jqresult_test.go
+++ b/jqresult/jqresult_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"cloud.google.com/go/spanner"
 	"github.com/apstndb/spaniter"
 	"github.com/wader/gojq"
 )
@@ -112,35 +111,6 @@ func TestLazyStopDoesNotDrain(t *testing.T) {
 	l.Stop()
 	if l.drained {
 		t.Fatal("Stop() must not drain rows")
-	}
-}
-
-func TestLazyCompleteOnStopDrains(t *testing.T) {
-	t.Parallel()
-
-	var pulls int
-	r := &RowIter{
-		redact:    true,
-		seqActive: true,
-		stopSeq:   func() {},
-		pull: func() (*spanner.Row, error, bool) {
-			pulls++
-			if pulls <= 2 {
-				return &spanner.Row{}, nil, true
-			}
-			return nil, nil, false
-		},
-	}
-	l := &Lazy{
-		completeOnStop: true,
-		rows:           r,
-	}
-	l.Stop()
-	if pulls != 3 {
-		t.Fatalf("Stop() pulled %d rows, want 3", pulls)
-	}
-	if !l.drained {
-		t.Fatal("Stop() with completeOnStop must drain")
 	}
 }
 

--- a/jqresult/lazy.go
+++ b/jqresult/lazy.go
@@ -13,9 +13,7 @@ type Lazy struct {
 	mu   sync.Mutex
 	ioMu sync.Mutex
 
-	redact         bool
-	dmlRowCount    bool
-	completeOnStop bool
+	redact bool
 	// encodeStats is nil in production; tests may inject a custom mapper.
 	encodeStats func(spaniter.Stats) (map[string]any, error)
 
@@ -32,8 +30,8 @@ type Lazy struct {
 }
 
 // NewLazy builds a lazy jq input. rowIter must not have been read yet; Lazy takes ownership and Stop()s it.
-func NewLazy(rowIter *spanner.RowIterator, redact bool, dmlRowCount bool, completeOnStop bool) *Lazy {
-	l := &Lazy{redact: redact, dmlRowCount: dmlRowCount, completeOnStop: completeOnStop}
+func NewLazy(rowIter *spanner.RowIterator, redact bool) *Lazy {
+	l := &Lazy{redact: redact}
 	l.rows = NewRowIter(rowIter, redact, RowToJSON)
 	l.rows.ioMu = &l.ioMu
 	return l
@@ -94,7 +92,7 @@ func (l *Lazy) encodeCapturedStats(stats spaniter.Stats) (map[string]any, error)
 	if l.encodeStats != nil {
 		return l.encodeStats(stats)
 	}
-	return StatsMapFromStats(stats, l.dmlRowCount)
+	return StatsMapFromStats(stats, false)
 }
 
 func (l *Lazy) ensureMetadata() error {
@@ -327,13 +325,8 @@ func (f *lazyStatsField) JQValueEach() any {
 	return pvs
 }
 
-// Stop releases the row iterator without draining unconsumed rows unless
-// completeOnStop requires the read-write statement to finish executing.
+// Stop releases the row iterator without draining unconsumed rows.
 func (l *Lazy) Stop() {
-	if l.completeOnStop {
-		_ = l.drain()
-		return
-	}
 	l.rows.Stop()
 }
 

--- a/jqresult/lazy.go
+++ b/jqresult/lazy.go
@@ -69,7 +69,7 @@ func (l *Lazy) drain() error {
 	}
 	var stats map[string]any
 	if drainErr == nil {
-		stats, drainErr = l.encodeCapturedStats(l.rows.Result().Stats)
+		stats, drainErr = l.statsMapFromResult(l.rows.Result())
 	}
 	l.ioMu.Unlock()
 
@@ -88,11 +88,11 @@ func (l *Lazy) drain() error {
 	return drainErr
 }
 
-func (l *Lazy) encodeCapturedStats(stats spaniter.Stats) (map[string]any, error) {
+func (l *Lazy) statsMapFromResult(result spaniter.RowIteratorResult) (map[string]any, error) {
 	if l.encodeStats != nil {
-		return l.encodeStats(stats)
+		return l.encodeStats(result.Stats)
 	}
-	return StatsMapFromStats(stats, false)
+	return StatsMapFromResult(result)
 }
 
 func (l *Lazy) ensureMetadata() error {

--- a/jqresult/lazy.go
+++ b/jqresult/lazy.go
@@ -14,6 +14,7 @@ type Lazy struct {
 	ioMu sync.Mutex
 
 	redact bool
+	dml    bool
 	// encodeStats is nil in production; tests may inject a custom mapper.
 	encodeStats func(spaniter.Stats) (map[string]any, error)
 
@@ -30,8 +31,8 @@ type Lazy struct {
 }
 
 // NewLazy builds a lazy jq input. rowIter must not have been read yet; Lazy takes ownership and Stop()s it.
-func NewLazy(rowIter *spanner.RowIterator, redact bool) *Lazy {
-	l := &Lazy{redact: redact}
+func NewLazy(rowIter *spanner.RowIterator, redact bool, dml bool) *Lazy {
+	l := &Lazy{redact: redact, dml: dml}
 	l.rows = NewRowIter(rowIter, redact, RowToJSON)
 	l.rows.ioMu = &l.ioMu
 	return l
@@ -69,11 +70,7 @@ func (l *Lazy) drain() error {
 	}
 	var stats map[string]any
 	if drainErr == nil {
-		statsMap := StatsMapFromStats
-		if l.encodeStats != nil {
-			statsMap = l.encodeStats
-		}
-		stats, drainErr = statsMap(l.rows.Result().Stats)
+		stats, drainErr = l.encodeCapturedStats(l.rows.Result().Stats)
 	}
 	l.ioMu.Unlock()
 
@@ -90,6 +87,13 @@ func (l *Lazy) drain() error {
 
 	l.rows.Stop()
 	return drainErr
+}
+
+func (l *Lazy) encodeCapturedStats(stats spaniter.Stats) (map[string]any, error) {
+	if l.encodeStats != nil {
+		return l.encodeStats(stats)
+	}
+	return StatsMapFromStats(stats, l.dml)
 }
 
 func (l *Lazy) ensureMetadata() error {

--- a/jqresult/lazy.go
+++ b/jqresult/lazy.go
@@ -13,8 +13,9 @@ type Lazy struct {
 	mu   sync.Mutex
 	ioMu sync.Mutex
 
-	redact bool
-	dml    bool
+	redact         bool
+	dmlRowCount    bool
+	completeOnStop bool
 	// encodeStats is nil in production; tests may inject a custom mapper.
 	encodeStats func(spaniter.Stats) (map[string]any, error)
 
@@ -31,8 +32,8 @@ type Lazy struct {
 }
 
 // NewLazy builds a lazy jq input. rowIter must not have been read yet; Lazy takes ownership and Stop()s it.
-func NewLazy(rowIter *spanner.RowIterator, redact bool, dml bool) *Lazy {
-	l := &Lazy{redact: redact, dml: dml}
+func NewLazy(rowIter *spanner.RowIterator, redact bool, dmlRowCount bool, completeOnStop bool) *Lazy {
+	l := &Lazy{redact: redact, dmlRowCount: dmlRowCount, completeOnStop: completeOnStop}
 	l.rows = NewRowIter(rowIter, redact, RowToJSON)
 	l.rows.ioMu = &l.ioMu
 	return l
@@ -93,7 +94,7 @@ func (l *Lazy) encodeCapturedStats(stats spaniter.Stats) (map[string]any, error)
 	if l.encodeStats != nil {
 		return l.encodeStats(stats)
 	}
-	return StatsMapFromStats(stats, l.dml)
+	return StatsMapFromStats(stats, l.dmlRowCount)
 }
 
 func (l *Lazy) ensureMetadata() error {
@@ -326,8 +327,13 @@ func (f *lazyStatsField) JQValueEach() any {
 	return pvs
 }
 
-// Stop releases the row iterator without draining unconsumed rows.
+// Stop releases the row iterator without draining unconsumed rows unless
+// completeOnStop requires the read-write statement to finish executing.
 func (l *Lazy) Stop() {
+	if l.completeOnStop {
+		_ = l.drain()
+		return
+	}
 	l.rows.Stop()
 }
 

--- a/jqresult/lazy.go
+++ b/jqresult/lazy.go
@@ -4,27 +4,18 @@ import (
 	"sync"
 
 	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spaniter"
 	"github.com/wader/gojq"
 )
-
-// StatsFunc builds the stats object after all rows have been read from rowIter.
-type StatsFunc func(rowIter *spanner.RowIterator) (map[string]any, error)
-
-// StatsFuncFromProto is a StatsFunc that uses BuildResultSet with nil rows (iterator already drained).
-func StatsFuncFromProto() StatsFunc {
-	return func(rowIter *spanner.RowIterator) (map[string]any, error) {
-		return StatsMap(rowIter, nil)
-	}
-}
 
 // Lazy is a JQValue root for a Spanner query result. Accessing stats drains rows; rows streams via gojq.Iter.
 type Lazy struct {
 	mu   sync.Mutex
 	ioMu sync.Mutex
 
-	rowIter *spanner.RowIterator
-	redact  bool
-	statsFn StatsFunc
+	redact bool
+	// encodeStats is nil in production; tests may inject a custom mapper.
+	encodeStats func(spaniter.Stats) (map[string]any, error)
 
 	metadata         map[string]any
 	metadataReady    bool
@@ -32,19 +23,15 @@ type Lazy struct {
 	stats            map[string]any
 	rows             *RowIter
 	materializedRows []any
-	rowsStreamDone bool
+	rowsStreamDone   bool
 
 	drained  bool
 	drainErr error
 }
 
 // NewLazy builds a lazy jq input. rowIter must not have been read yet; Lazy takes ownership and Stop()s it.
-func NewLazy(rowIter *spanner.RowIterator, redact bool, statsFn StatsFunc) *Lazy {
-	l := &Lazy{
-		rowIter: rowIter,
-		redact:  redact,
-		statsFn: statsFn,
-	}
+func NewLazy(rowIter *spanner.RowIterator, redact bool) *Lazy {
+	l := &Lazy{redact: redact}
 	l.rows = NewRowIter(rowIter, redact, RowToJSON)
 	l.rows.ioMu = &l.ioMu
 	return l
@@ -81,8 +68,12 @@ func (l *Lazy) drain() error {
 		materializedRows = append(cachedRows, remaining...)
 	}
 	var stats map[string]any
-	if drainErr == nil && l.statsFn != nil {
-		stats, drainErr = l.statsFn(l.rowIter)
+	if drainErr == nil {
+		statsMap := StatsMapFromStats
+		if l.encodeStats != nil {
+			statsMap = l.encodeStats
+		}
+		stats, drainErr = statsMap(l.rows.Result().Stats)
 	}
 	l.ioMu.Unlock()
 
@@ -128,7 +119,7 @@ func (l *Lazy) ensureMetadata() error {
 		l.ioMu.Unlock()
 		return err
 	}
-	m, err := MetadataMap(l.rowIter)
+	m, err := MetadataMapFromMetadata(l.rows.Result().Metadata)
 	l.ioMu.Unlock()
 
 	l.mu.Lock()

--- a/jqresult/pipeline.go
+++ b/jqresult/pipeline.go
@@ -25,7 +25,7 @@ func Execute(code *gojq.Code, mode InputMode, rowIter *spanner.RowIterator, rs *
 		if rowIter == nil {
 			return nil, func() {}, fmt.Errorf("lazy mode requires an unread RowIterator")
 		}
-		lazy := NewLazy(rowIter, redactRows, StatsFuncFromProto())
+		lazy := NewLazy(rowIter, redactRows)
 		return code.Run(lazy), lazy.Stop, nil
 	default:
 		return nil, func() {}, fmt.Errorf("unknown jq input mode: %s", mode)

--- a/jqresult/pipeline.go
+++ b/jqresult/pipeline.go
@@ -10,7 +10,8 @@ import (
 
 // Execute runs jq. For eager mode, rs must be set and rowIter is ignored.
 // For lazy mode, rowIter must be unread; cleanup releases the iterator state.
-func Execute(code *gojq.Code, mode InputMode, rowIter *spanner.RowIterator, rs *sppb.ResultSet, redactRows bool) (gojq.Iter, func(), error) {
+// When dml is true, stats encoding preserves standard DML row_count_exact:0.
+func Execute(code *gojq.Code, mode InputMode, rowIter *spanner.RowIterator, rs *sppb.ResultSet, redactRows bool, dml bool) (gojq.Iter, func(), error) {
 	switch mode {
 	case InputEager:
 		if rs == nil {
@@ -25,7 +26,7 @@ func Execute(code *gojq.Code, mode InputMode, rowIter *spanner.RowIterator, rs *
 		if rowIter == nil {
 			return nil, func() {}, fmt.Errorf("lazy mode requires an unread RowIterator")
 		}
-		lazy := NewLazy(rowIter, redactRows)
+		lazy := NewLazy(rowIter, redactRows, dml)
 		return code.Run(lazy), lazy.Stop, nil
 	default:
 		return nil, func() {}, fmt.Errorf("unknown jq input mode: %s", mode)

--- a/jqresult/pipeline.go
+++ b/jqresult/pipeline.go
@@ -10,10 +10,9 @@ import (
 
 // Execute runs jq. For eager mode, rs must be set and rowIter is ignored.
 // For lazy mode, rowIter must be unread; cleanup releases the iterator state.
-// When dmlRowCount is true, stats encoding preserves standard DML row_count_exact:0.
-// When completeOnStop is true, lazy cleanup drains the RowIterator so read-write
-// statements execute even when the jq filter never touches input.
-func Execute(code *gojq.Code, mode InputMode, rowIter *spanner.RowIterator, rs *sppb.ResultSet, redactRows bool, dmlRowCount bool, completeOnStop bool) (gojq.Iter, func(), error) {
+// Lazy mode is intended for read-only queries; read-write callers should
+// materialize first and use eager mode.
+func Execute(code *gojq.Code, mode InputMode, rowIter *spanner.RowIterator, rs *sppb.ResultSet, redactRows bool) (gojq.Iter, func(), error) {
 	switch mode {
 	case InputEager:
 		if rs == nil {
@@ -28,7 +27,7 @@ func Execute(code *gojq.Code, mode InputMode, rowIter *spanner.RowIterator, rs *
 		if rowIter == nil {
 			return nil, func() {}, fmt.Errorf("lazy mode requires an unread RowIterator")
 		}
-		lazy := NewLazy(rowIter, redactRows, dmlRowCount, completeOnStop)
+		lazy := NewLazy(rowIter, redactRows)
 		return code.Run(lazy), lazy.Stop, nil
 	default:
 		return nil, func() {}, fmt.Errorf("unknown jq input mode: %s", mode)

--- a/jqresult/pipeline.go
+++ b/jqresult/pipeline.go
@@ -10,8 +10,10 @@ import (
 
 // Execute runs jq. For eager mode, rs must be set and rowIter is ignored.
 // For lazy mode, rowIter must be unread; cleanup releases the iterator state.
-// When dml is true, stats encoding preserves standard DML row_count_exact:0.
-func Execute(code *gojq.Code, mode InputMode, rowIter *spanner.RowIterator, rs *sppb.ResultSet, redactRows bool, dml bool) (gojq.Iter, func(), error) {
+// When dmlRowCount is true, stats encoding preserves standard DML row_count_exact:0.
+// When completeOnStop is true, lazy cleanup drains the RowIterator so read-write
+// statements execute even when the jq filter never touches input.
+func Execute(code *gojq.Code, mode InputMode, rowIter *spanner.RowIterator, rs *sppb.ResultSet, redactRows bool, dmlRowCount bool, completeOnStop bool) (gojq.Iter, func(), error) {
 	switch mode {
 	case InputEager:
 		if rs == nil {
@@ -26,7 +28,7 @@ func Execute(code *gojq.Code, mode InputMode, rowIter *spanner.RowIterator, rs *
 		if rowIter == nil {
 			return nil, func() {}, fmt.Errorf("lazy mode requires an unread RowIterator")
 		}
-		lazy := NewLazy(rowIter, redactRows, dml)
+		lazy := NewLazy(rowIter, redactRows, dmlRowCount, completeOnStop)
 		return code.Run(lazy), lazy.Stop, nil
 	default:
 		return nil, func() {}, fmt.Errorf("unknown jq input mode: %s", mode)

--- a/jqresult/pipeline_test.go
+++ b/jqresult/pipeline_test.go
@@ -11,7 +11,7 @@ func TestExecuteLazyNilRowIter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = Execute(code, InputLazy, nil, nil, false)
+	_, _, err = Execute(code, InputLazy, nil, nil, false, false)
 	if err == nil {
 		t.Fatal("expected error for nil rowIter in lazy mode")
 	}
@@ -24,7 +24,7 @@ func TestExecuteEagerNilResultSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = Execute(code, InputEager, nil, nil, false)
+	_, _, err = Execute(code, InputEager, nil, nil, false, false)
 	if err == nil {
 		t.Fatal("expected error for nil ResultSet in eager mode")
 	}

--- a/jqresult/pipeline_test.go
+++ b/jqresult/pipeline_test.go
@@ -11,7 +11,7 @@ func TestExecuteLazyNilRowIter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = Execute(code, InputLazy, nil, nil, false, false, false)
+	_, _, err = Execute(code, InputLazy, nil, nil, false)
 	if err == nil {
 		t.Fatal("expected error for nil rowIter in lazy mode")
 	}
@@ -24,7 +24,7 @@ func TestExecuteEagerNilResultSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = Execute(code, InputEager, nil, nil, false, false, false)
+	_, _, err = Execute(code, InputEager, nil, nil, false)
 	if err == nil {
 		t.Fatal("expected error for nil ResultSet in eager mode")
 	}

--- a/jqresult/pipeline_test.go
+++ b/jqresult/pipeline_test.go
@@ -11,7 +11,7 @@ func TestExecuteLazyNilRowIter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = Execute(code, InputLazy, nil, nil, false, false)
+	_, _, err = Execute(code, InputLazy, nil, nil, false, false, false)
 	if err == nil {
 		t.Fatal("expected error for nil rowIter in lazy mode")
 	}
@@ -24,7 +24,7 @@ func TestExecuteEagerNilResultSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = Execute(code, InputEager, nil, nil, false, false)
+	_, _, err = Execute(code, InputEager, nil, nil, false, false, false)
 	if err == nil {
 		t.Fatal("expected error for nil ResultSet in eager mode")
 	}

--- a/jqresult/protojson.go
+++ b/jqresult/protojson.go
@@ -3,14 +3,13 @@ package jqresult
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/execspansql/resultset"
 	"github.com/apstndb/spaniter"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // ProtoToMap marshals a protobuf message with protojson and decodes to map[string]any.
@@ -28,32 +27,24 @@ func ProtoToMap(m proto.Message) (map[string]any, error) {
 	return object, nil
 }
 
-// MetadataMap returns the metadata object for a row iterator (before rows are consumed).
-func MetadataMap(rowIter *spanner.RowIterator) (map[string]any, error) {
-	obj, err := ProtoToMap(&sppb.ResultSet{Metadata: rowIter.Metadata})
-	if err != nil {
-		return nil, err
+// MetadataMapFromMetadata returns the metadata object for jq input.
+func MetadataMapFromMetadata(metadata *sppb.ResultSetMetadata) (map[string]any, error) {
+	if metadata == nil {
+		return nil, nil
 	}
-	if m, ok := obj["metadata"].(map[string]any); ok {
-		return m, nil
-	}
-	return nil, nil
+	return ProtoToMap(metadata)
 }
 
-// StatsMap builds the stats object after rowIter has been fully consumed.
-func StatsMap(rowIter *spanner.RowIterator, rows []*structpb.ListValue) (map[string]any, error) {
-	rs, err := BuildResultSet(rows, rowIter)
+// StatsMapFromStats returns the stats object for jq input from captured spaniter stats.
+func StatsMapFromStats(stats spaniter.Stats) (map[string]any, error) {
+	resultStats, err := stats.ResultSetStats()
 	if err != nil {
 		return nil, err
 	}
-	obj, err := ProtoToMap(rs)
-	if err != nil {
-		return nil, err
+	if resultStats == nil {
+		return nil, nil
 	}
-	if s, ok := obj["stats"].(map[string]any); ok {
-		return s, nil
-	}
-	return nil, nil
+	return ProtoToMap(resultStats)
 }
 
 // ResultSetMap materializes a full ResultSet as a jq input map (eager mode).
@@ -61,35 +52,11 @@ func ResultSetMap(rs *sppb.ResultSet) (map[string]any, error) {
 	return ProtoToMap(rs)
 }
 
-// BuildResultSet constructs ResultSet stats from a consumed row iterator.
-func BuildResultSet(rows []*structpb.ListValue, rowIter *spanner.RowIterator) (*sppb.ResultSet, error) {
-	if rowIter == nil {
-		return nil, errors.New("nil row iterator")
-	}
-	return BuildResultSetFromParts(rows, rowIter.Metadata, spaniter.Stats{
-		QueryPlan:  rowIter.QueryPlan,
-		QueryStats: rowIter.QueryStats,
-		RowCount:   rowIter.RowCount,
-	})
-}
-
-// BuildResultSetFromParts constructs a ResultSet from materialized rows and
-// consumed iterator metadata. rows may be nil when row values are intentionally
-// redacted; metadata and stats are still preserved from the drained iterator.
-func BuildResultSetFromParts(rows []*structpb.ListValue, metadata *sppb.ResultSetMetadata, stats spaniter.Stats) (*sppb.ResultSet, error) {
-	out := &sppb.ResultSet{
-		Rows:     rows,
-		Metadata: metadata,
-	}
-
-	if stats.IsZero() {
-		return out, nil
-	}
-
-	resultStats, err := stats.ResultSetStats()
+// ResultSetMapFromRowIterator materializes rowIter and returns the jq input map.
+func ResultSetMapFromRowIterator(rowIter *spanner.RowIterator, redact bool) (map[string]any, error) {
+	rs, err := resultset.Materialize(rowIter, redact)
 	if err != nil {
 		return nil, err
 	}
-	out.Stats = resultStats
-	return out, nil
+	return ResultSetMap(rs)
 }

--- a/jqresult/protojson.go
+++ b/jqresult/protojson.go
@@ -36,11 +36,12 @@ func MetadataMapFromMetadata(metadata *sppb.ResultSetMetadata) (map[string]any, 
 }
 
 // StatsMapFromStats returns the stats object for jq input from captured spaniter stats.
-// When dml is true, stats use ResultSetStatsForDML for standard DML row counts.
-func StatsMapFromStats(stats spaniter.Stats, dml bool) (map[string]any, error) {
+// When dmlRowCount is true, stats use ResultSetStatsForDML for standard DML row counts.
+// PLAN mode callers must pass false.
+func StatsMapFromStats(stats spaniter.Stats, dmlRowCount bool) (map[string]any, error) {
 	var resultStats *sppb.ResultSetStats
 	var err error
-	if dml {
+	if dmlRowCount {
 		resultStats, err = stats.ResultSetStatsForDML()
 	} else {
 		resultStats, err = stats.ResultSetStats()
@@ -60,8 +61,8 @@ func ResultSetMap(rs *sppb.ResultSet) (map[string]any, error) {
 }
 
 // ResultSetMapFromRowIterator materializes rowIter and returns the jq input map.
-func ResultSetMapFromRowIterator(rowIter *spanner.RowIterator, redact bool, dml bool) (map[string]any, error) {
-	rs, err := resultset.Materialize(rowIter, redact, dml)
+func ResultSetMapFromRowIterator(rowIter *spanner.RowIterator, redact bool, dmlRowCount bool) (map[string]any, error) {
+	rs, err := resultset.Materialize(rowIter, redact, dmlRowCount)
 	if err != nil {
 		return nil, err
 	}

--- a/jqresult/protojson.go
+++ b/jqresult/protojson.go
@@ -36,16 +36,14 @@ func MetadataMapFromMetadata(metadata *sppb.ResultSetMetadata) (map[string]any, 
 }
 
 // StatsMapFromStats returns the stats object for jq input from captured spaniter stats.
-// When dmlRowCount is true, stats use ResultSetStatsForDML for standard DML row counts.
-// PLAN mode callers must pass false.
+// When dmlRowCount is true, stats use DML exact row-count encoding. PLAN mode
+// callers must pass false.
 func StatsMapFromStats(stats spaniter.Stats, dmlRowCount bool) (map[string]any, error) {
-	var resultStats *sppb.ResultSetStats
-	var err error
+	enc := spaniter.StatsEncodingDefault
 	if dmlRowCount {
-		resultStats, err = stats.ResultSetStatsForDML()
-	} else {
-		resultStats, err = stats.ResultSetStats()
+		enc = spaniter.StatsEncodingDMLExact
 	}
+	resultStats, err := stats.ResultSetStatsEncoded(enc)
 	if err != nil {
 		return nil, err
 	}

--- a/jqresult/protojson.go
+++ b/jqresult/protojson.go
@@ -35,15 +35,9 @@ func MetadataMapFromMetadata(metadata *sppb.ResultSetMetadata) (map[string]any, 
 	return ProtoToMap(metadata)
 }
 
-// StatsMapFromStats returns the stats object for jq input from captured spaniter stats.
-// When dmlRowCount is true, stats use DML exact row-count encoding. PLAN mode
-// callers must pass false.
-func StatsMapFromStats(stats spaniter.Stats, dmlRowCount bool) (map[string]any, error) {
-	enc := spaniter.StatsEncodingDefault
-	if dmlRowCount {
-		enc = spaniter.StatsEncodingDMLExact
-	}
-	resultStats, err := stats.ResultSetStatsEncoded(enc)
+// StatsMapFromResult returns the stats object for jq input from captured iterator state.
+func StatsMapFromResult(result spaniter.RowIteratorResult) (map[string]any, error) {
+	resultStats, err := result.StatsProto()
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +53,8 @@ func ResultSetMap(rs *sppb.ResultSet) (map[string]any, error) {
 }
 
 // ResultSetMapFromRowIterator materializes rowIter and returns the jq input map.
-func ResultSetMapFromRowIterator(rowIter *spanner.RowIterator, redact bool, dmlRowCount bool) (map[string]any, error) {
-	rs, err := resultset.Materialize(rowIter, redact, dmlRowCount)
+func ResultSetMapFromRowIterator(rowIter *spanner.RowIterator, redact bool, opts ...spaniter.Option) (map[string]any, error) {
+	rs, err := resultset.Materialize(rowIter, redact, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/jqresult/protojson.go
+++ b/jqresult/protojson.go
@@ -36,8 +36,15 @@ func MetadataMapFromMetadata(metadata *sppb.ResultSetMetadata) (map[string]any, 
 }
 
 // StatsMapFromStats returns the stats object for jq input from captured spaniter stats.
-func StatsMapFromStats(stats spaniter.Stats) (map[string]any, error) {
-	resultStats, err := stats.ResultSetStats()
+// When dml is true, stats use ResultSetStatsForDML for standard DML row counts.
+func StatsMapFromStats(stats spaniter.Stats, dml bool) (map[string]any, error) {
+	var resultStats *sppb.ResultSetStats
+	var err error
+	if dml {
+		resultStats, err = stats.ResultSetStatsForDML()
+	} else {
+		resultStats, err = stats.ResultSetStats()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -53,8 +60,8 @@ func ResultSetMap(rs *sppb.ResultSet) (map[string]any, error) {
 }
 
 // ResultSetMapFromRowIterator materializes rowIter and returns the jq input map.
-func ResultSetMapFromRowIterator(rowIter *spanner.RowIterator, redact bool) (map[string]any, error) {
-	rs, err := resultset.Materialize(rowIter, redact)
+func ResultSetMapFromRowIterator(rowIter *spanner.RowIterator, redact bool, dml bool) (map[string]any, error) {
+	rs, err := resultset.Materialize(rowIter, redact, dml)
 	if err != nil {
 		return nil, err
 	}

--- a/jqresult/protojson_test.go
+++ b/jqresult/protojson_test.go
@@ -9,7 +9,7 @@ import (
 func TestStatsMapFromStatsEmpty(t *testing.T) {
 	t.Parallel()
 
-	got, err := StatsMapFromStats(spaniter.Stats{})
+	got, err := StatsMapFromStats(spaniter.Stats{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -21,12 +21,27 @@ func TestStatsMapFromStatsEmpty(t *testing.T) {
 func TestStatsMapFromStatsQueryStats(t *testing.T) {
 	t.Parallel()
 
-	got, err := StatsMapFromStats(spaniter.Stats{QueryStats: map[string]any{}})
+	got, err := StatsMapFromStats(spaniter.Stats{QueryStats: map[string]any{}}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got == nil {
 		t.Fatal("stats map = nil, want empty object")
+	}
+}
+
+func TestStatsMapFromStatsDMLZeroRowCount(t *testing.T) {
+	t.Parallel()
+
+	got, err := StatsMapFromStats(spaniter.Stats{RowCount: 0}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("stats map = nil, want rowCountExact")
+	}
+	if got["rowCountExact"] != "0" {
+		t.Fatalf("rowCountExact = %v, want \"0\"", got["rowCountExact"])
 	}
 }
 
@@ -45,7 +60,7 @@ func TestMetadataMapFromMetadataNil(t *testing.T) {
 func TestResultSetMapFromRowIteratorNil(t *testing.T) {
 	t.Parallel()
 
-	_, err := ResultSetMapFromRowIterator(nil, false)
+	_, err := ResultSetMapFromRowIterator(nil, false, false)
 	if err == nil {
 		t.Fatal("error = nil, want nil row iterator error")
 	}

--- a/jqresult/protojson_test.go
+++ b/jqresult/protojson_test.go
@@ -1,0 +1,52 @@
+package jqresult
+
+import (
+	"testing"
+
+	"github.com/apstndb/spaniter"
+)
+
+func TestStatsMapFromStatsEmpty(t *testing.T) {
+	t.Parallel()
+
+	got, err := StatsMapFromStats(spaniter.Stats{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("stats map = %v, want nil", got)
+	}
+}
+
+func TestStatsMapFromStatsQueryStats(t *testing.T) {
+	t.Parallel()
+
+	got, err := StatsMapFromStats(spaniter.Stats{QueryStats: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("stats map = nil, want empty object")
+	}
+}
+
+func TestMetadataMapFromMetadataNil(t *testing.T) {
+	t.Parallel()
+
+	got, err := MetadataMapFromMetadata(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("metadata map = %v, want nil", got)
+	}
+}
+
+func TestResultSetMapFromRowIteratorNil(t *testing.T) {
+	t.Parallel()
+
+	_, err := ResultSetMapFromRowIterator(nil, false)
+	if err == nil {
+		t.Fatal("error = nil, want nil row iterator error")
+	}
+}

--- a/jqresult/protojson_test.go
+++ b/jqresult/protojson_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/apstndb/spaniter"
 )
 
-func TestStatsMapFromStatsEmpty(t *testing.T) {
+func TestStatsMapFromResultEmpty(t *testing.T) {
 	t.Parallel()
 
-	got, err := StatsMapFromStats(spaniter.Stats{}, false)
+	got, err := StatsMapFromResult(spaniter.RowIteratorResult{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -18,30 +18,17 @@ func TestStatsMapFromStatsEmpty(t *testing.T) {
 	}
 }
 
-func TestStatsMapFromStatsQueryStats(t *testing.T) {
+func TestStatsMapFromResultQueryStats(t *testing.T) {
 	t.Parallel()
 
-	got, err := StatsMapFromStats(spaniter.Stats{QueryStats: map[string]any{}}, false)
+	got, err := StatsMapFromResult(spaniter.RowIteratorResult{
+		Stats: spaniter.Stats{QueryStats: map[string]any{}},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got == nil {
 		t.Fatal("stats map = nil, want empty object")
-	}
-}
-
-func TestStatsMapFromStatsDMLZeroRowCount(t *testing.T) {
-	t.Parallel()
-
-	got, err := StatsMapFromStats(spaniter.Stats{RowCount: 0}, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got == nil {
-		t.Fatal("stats map = nil, want rowCountExact")
-	}
-	if got["rowCountExact"] != "0" {
-		t.Fatalf("rowCountExact = %v, want \"0\"", got["rowCountExact"])
 	}
 }
 
@@ -60,7 +47,7 @@ func TestMetadataMapFromMetadataNil(t *testing.T) {
 func TestResultSetMapFromRowIteratorNil(t *testing.T) {
 	t.Parallel()
 
-	_, err := ResultSetMapFromRowIterator(nil, false, false)
+	_, err := ResultSetMapFromRowIterator(nil, false)
 	if err == nil {
 		t.Fatal("error = nil, want nil row iterator error")
 	}

--- a/jqresult/rowiter.go
+++ b/jqresult/rowiter.go
@@ -50,10 +50,7 @@ func (r *RowIter) ensureSeq() {
 		return
 	}
 	r.seqActive = true
-	seq := spaniter.RowIteratorSeq(r.rowIter,
-		spaniter.WithResult(&r.result),
-		spaniter.WithDrainOnEarlyStop(),
-	)
+	seq := spaniter.RowIteratorSeq(r.rowIter, spaniter.WithResult(&r.result))
 	r.pull, r.stopSeq = iter.Pull2(seq)
 }
 
@@ -78,6 +75,9 @@ func (r *RowIter) primeUnlocked() error {
 	if !ok {
 		return err
 	}
+	if err != nil {
+		return err
+	}
 	r.primedRow = row
 	return nil
 }
@@ -94,6 +94,9 @@ func (r *RowIter) nextRow() (*spanner.Row, error) {
 	}
 	row, err, ok := r.pull()
 	if !ok {
+		return nil, err
+	}
+	if err != nil {
 		return nil, err
 	}
 	return row, nil
@@ -164,7 +167,6 @@ func (r *RowIter) Stop() {
 	r.stopped = true
 	if r.stopSeq != nil {
 		r.stopSeq()
-		return
 	}
 	if r.rowIter != nil {
 		r.rowIter.Stop()

--- a/jqresult/rowiter.go
+++ b/jqresult/rowiter.go
@@ -1,7 +1,6 @@
 package jqresult
 
 import (
-	"iter"
 	"sync"
 
 	"cloud.google.com/go/spanner"
@@ -50,8 +49,7 @@ func (r *RowIter) ensureSeq() {
 		return
 	}
 	r.seqActive = true
-	seq := spaniter.RowIteratorSeq(r.rowIter, spaniter.WithResult(&r.result))
-	r.pull, r.stopSeq = iter.Pull2(seq)
+	r.pull, r.stopSeq = spaniter.PullRowIteratorSeq(r.rowIter, spaniter.WithResult(&r.result))
 }
 
 // Prime reads the first row (or iterator.Done) so metadata is populated.
@@ -75,9 +73,6 @@ func (r *RowIter) primeUnlocked() error {
 	if !ok {
 		return err
 	}
-	if err != nil {
-		return err
-	}
 	r.primedRow = row
 	return nil
 }
@@ -94,9 +89,6 @@ func (r *RowIter) nextRow() (*spanner.Row, error) {
 	}
 	row, err, ok := r.pull()
 	if !ok {
-		return nil, err
-	}
-	if err != nil {
 		return nil, err
 	}
 	return row, nil

--- a/jqresult/rowiter.go
+++ b/jqresult/rowiter.go
@@ -1,20 +1,25 @@
 package jqresult
 
 import (
-	"errors"
+	"iter"
 	"sync"
 
 	"cloud.google.com/go/spanner"
-	"google.golang.org/api/iterator"
+	"github.com/apstndb/spaniter"
 )
 
 // RowIter streams query rows as jq-compatible values ([]any per row, matching protojson ResultSet rows).
 type RowIter struct {
 	ioMu      *sync.Mutex
-	iter      *spanner.RowIterator
+	rowIter   *spanner.RowIterator
 	redact    bool
 	rowToJSON func(*spanner.Row) (any, error)
 	stopped   bool
+
+	result    spaniter.RowIteratorResult
+	pull      func() (*spanner.Row, error, bool)
+	stopSeq   func()
+	seqActive bool
 
 	primedRow *spanner.Row
 	primed    bool
@@ -24,7 +29,12 @@ func NewRowIter(rowIter *spanner.RowIterator, redact bool, rowToJSON func(*spann
 	if rowToJSON == nil {
 		rowToJSON = RowToJSON
 	}
-	return &RowIter{iter: rowIter, redact: redact, rowToJSON: rowToJSON}
+	return &RowIter{rowIter: rowIter, redact: redact, rowToJSON: rowToJSON}
+}
+
+// Result returns lifecycle data captured by spaniter while rows are consumed.
+func (r *RowIter) Result() spaniter.RowIteratorResult {
+	return r.result
 }
 
 func (r *RowIter) lockIO() func() {
@@ -35,7 +45,19 @@ func (r *RowIter) lockIO() func() {
 	return r.ioMu.Unlock
 }
 
-// Prime reads the first row (or iterator.Done) so rowIter.Metadata is populated.
+func (r *RowIter) ensureSeq() {
+	if r.seqActive || r.stopped || r.rowIter == nil {
+		return
+	}
+	r.seqActive = true
+	seq := spaniter.RowIteratorSeq(r.rowIter,
+		spaniter.WithResult(&r.result),
+		spaniter.WithDrainOnEarlyStop(),
+	)
+	r.pull, r.stopSeq = iter.Pull2(seq)
+}
+
+// Prime reads the first row (or iterator.Done) so metadata is populated.
 // The first row is buffered for the next Next call when present.
 func (r *RowIter) Prime() error {
 	unlock := r.lockIO()
@@ -48,11 +70,12 @@ func (r *RowIter) primeUnlocked() error {
 		return nil
 	}
 	r.primed = true
-	row, err := r.iter.Next()
-	if errors.Is(err, iterator.Done) {
+	r.ensureSeq()
+	if r.pull == nil {
 		return nil
 	}
-	if err != nil {
+	row, err, ok := r.pull()
+	if !ok {
 		return err
 	}
 	r.primedRow = row
@@ -65,7 +88,15 @@ func (r *RowIter) nextRow() (*spanner.Row, error) {
 		r.primedRow = nil
 		return row, nil
 	}
-	return r.iter.Next()
+	r.ensureSeq()
+	if r.pull == nil {
+		return nil, nil
+	}
+	row, err, ok := r.pull()
+	if !ok {
+		return nil, err
+	}
+	return row, nil
 }
 
 func (r *RowIter) Next() (any, bool) {
@@ -79,7 +110,7 @@ func (r *RowIter) nextUnlocked() (any, bool) {
 		return nil, false
 	}
 	row, err := r.nextRow()
-	if errors.Is(err, iterator.Done) {
+	if row == nil && err == nil {
 		return nil, false
 	}
 	if err != nil {
@@ -106,7 +137,7 @@ func (r *RowIter) drainUnlocked() ([]any, error) {
 	var rows []any
 	for {
 		row, err := r.nextRow()
-		if errors.Is(err, iterator.Done) {
+		if row == nil && err == nil {
 			return rows, nil
 		}
 		if err != nil {
@@ -131,5 +162,11 @@ func (r *RowIter) Stop() {
 		return
 	}
 	r.stopped = true
-	r.iter.Stop()
+	if r.stopSeq != nil {
+		r.stopSeq()
+		return
+	}
+	if r.rowIter != nil {
+		r.rowIter.Stop()
+	}
 }

--- a/jqresult/rowiter.go
+++ b/jqresult/rowiter.go
@@ -167,6 +167,7 @@ func (r *RowIter) Stop() {
 	r.stopped = true
 	if r.stopSeq != nil {
 		r.stopSeq()
+		return
 	}
 	if r.rowIter != nil {
 		r.rowIter.Stop()

--- a/jqresult/rowiter_test.go
+++ b/jqresult/rowiter_test.go
@@ -1,0 +1,71 @@
+package jqresult
+
+import (
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+)
+
+func TestRowIterPrimePropagatesTerminalError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("terminal iteration error")
+	r := &RowIter{
+		seqActive: true,
+		pull: func() (*spanner.Row, error, bool) {
+			return nil, sentinel, true
+		},
+	}
+
+	if err := r.primeUnlocked(); !errors.Is(err, sentinel) {
+		t.Fatalf("primeUnlocked() = %v, want %v", err, sentinel)
+	}
+}
+
+func TestRowIterNextRowPropagatesTerminalError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("terminal iteration error")
+	r := &RowIter{
+		seqActive: true,
+		primed:    true,
+		pull: func() (*spanner.Row, error, bool) {
+			return nil, sentinel, true
+		},
+	}
+
+	row, err := r.nextRow()
+	if row != nil {
+		t.Fatalf("row = %v, want nil", row)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want %v", err, sentinel)
+	}
+}
+
+func TestRowIterStopDoesNotDrainRemainingRows(t *testing.T) {
+	t.Parallel()
+
+	var pullsAfterPrime int
+	first := true
+	r := &RowIter{
+		seqActive: true,
+		stopSeq:   func() {},
+		pull: func() (*spanner.Row, error, bool) {
+			if first {
+				first = false
+				return &spanner.Row{}, nil, true
+			}
+			pullsAfterPrime++
+			return nil, nil, false
+		},
+	}
+	if err := r.primeUnlocked(); err != nil {
+		t.Fatal(err)
+	}
+	r.Stop()
+	if pullsAfterPrime != 0 {
+		t.Fatalf("Stop() drained %d rows, want 0", pullsAfterPrime)
+	}
+}

--- a/jqresult/rowiter_test.go
+++ b/jqresult/rowiter_test.go
@@ -14,7 +14,7 @@ func TestRowIterPrimePropagatesTerminalError(t *testing.T) {
 	r := &RowIter{
 		seqActive: true,
 		pull: func() (*spanner.Row, error, bool) {
-			return nil, sentinel, true
+			return nil, sentinel, false
 		},
 	}
 
@@ -31,7 +31,7 @@ func TestRowIterNextRowPropagatesTerminalError(t *testing.T) {
 		seqActive: true,
 		primed:    true,
 		pull: func() (*spanner.Row, error, bool) {
-			return nil, sentinel, true
+			return nil, sentinel, false
 		},
 	}
 

--- a/jqresult/rowjson.go
+++ b/jqresult/rowjson.go
@@ -3,23 +3,17 @@ package jqresult
 import (
 	"bytes"
 	"encoding/json"
-	"slices"
-	"spheric.cloud/xiter"
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/execspansql/resultset"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// RowToListValue converts a Spanner row to structpb.ListValue.
-func RowToListValue(r *spanner.Row) *structpb.ListValue {
-	return &structpb.ListValue{Values: slices.Collect(xiter.Map(xiter.Range(0, r.Size()), r.ColumnValue))}
-}
-
 // RowToJSON encodes one row the same way as protojson on a single-row ResultSet (array-shaped row).
 func RowToJSON(r *spanner.Row) (any, error) {
-	rs := &sppb.ResultSet{Rows: []*structpb.ListValue{RowToListValue(r)}}
+	rs := &sppb.ResultSet{Rows: []*structpb.ListValue{resultset.RowToListValue(r)}}
 	b, err := protojson.Marshal(rs)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -174,16 +174,20 @@ func (r readWrite) isQueryMode()      {}
 func (p partitionedDML) isQueryMode() {}
 
 func runInNewTransaction(ctx context.Context, client *spanner.Client, stmt spanner.Statement, opts spanner.QueryOptions, mode queryMode, reductRows bool) (*sppb.ResultSet, error) {
+	dml := false
+	if _, ok := mode.(readWrite); ok {
+		dml = true
+	}
 	var rs *sppb.ResultSet
 	switch mode := mode.(type) {
 	case readWrite:
 		_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) (err error) {
-			rs, err = resultset.Materialize(tx.QueryWithOptions(ctx, stmt, opts), reductRows)
+			rs, err = resultset.Materialize(tx.QueryWithOptions(ctx, stmt, opts), reductRows, dml)
 			return err
 		})
 		return rs, err
 	case single:
-		return resultset.Materialize(client.Single().WithTimestampBound(mode.TimestampBound).QueryWithOptions(ctx, stmt, opts), reductRows)
+		return resultset.Materialize(client.Single().WithTimestampBound(mode.TimestampBound).QueryWithOptions(ctx, stmt, opts), reductRows, dml)
 	case partitionedDML:
 		count, err := client.PartitionedUpdateWithOptions(ctx, stmt, opts)
 		return &sppb.ResultSet{
@@ -486,7 +490,7 @@ func runJqOutput(
 		if err != nil {
 			return err
 		}
-		iter, cleanup, err := jqresult.Execute(jqCode, jqMode, nil, rs, o.RedactRows)
+		iter, cleanup, err := jqresult.Execute(jqCode, jqMode, nil, rs, o.RedactRows, false)
 		if err != nil {
 			return err
 		}
@@ -503,7 +507,7 @@ func runJqOutput(
 			if err != nil {
 				return err
 			}
-			return runJqOnRowIter(tx.QueryWithOptions(ctx, stmt, opts), o.RedactRows, jqMode, jqCode, enc)
+			return runJqOnRowIter(tx.QueryWithOptions(ctx, stmt, opts), o.RedactRows, jqMode, jqCode, enc, true)
 		})
 		if err != nil {
 			return err
@@ -516,7 +520,7 @@ func runJqOutput(
 			return err
 		}
 		rowIter := client.Single().WithTimestampBound(mode.TimestampBound).QueryWithOptions(ctx, stmt, opts)
-		return runJqOnRowIter(rowIter, o.RedactRows, jqMode, jqCode, enc)
+		return runJqOnRowIter(rowIter, o.RedactRows, jqMode, jqCode, enc, false)
 	case partitionedDML:
 		// Eager mode is handled above via runInNewTransaction.
 		return fmt.Errorf("--jq-input-mode=lazy is not supported for partitioned DML")
@@ -531,8 +535,9 @@ func runJqOnRowIter(
 	jqMode jqresult.InputMode,
 	jqCode *gojq.Code,
 	enc encoder,
+	dml bool,
 ) error {
-	iter, cleanup, err := jqresult.Execute(jqCode, jqMode, rowIter, nil, redactRows)
+	iter, cleanup, err := jqresult.Execute(jqCode, jqMode, rowIter, nil, redactRows, dml)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -173,21 +173,31 @@ func (s single) isQueryMode()         {}
 func (r readWrite) isQueryMode()      {}
 func (p partitionedDML) isQueryMode() {}
 
-func runInNewTransaction(ctx context.Context, client *spanner.Client, stmt spanner.Statement, opts spanner.QueryOptions, mode queryMode, reductRows bool) (*sppb.ResultSet, error) {
-	dml := false
-	if _, ok := mode.(readWrite); ok {
-		dml = true
+// readWriteStatFlags reports whether read-write results should encode exact DML
+// row counts and whether lazy jq must fully consume the RowIterator on cleanup.
+func readWriteStatFlags(mode queryMode, opts spanner.QueryOptions) (dmlRowCount, completeOnStop bool) {
+	if _, ok := mode.(readWrite); !ok {
+		return false, false
 	}
+	completeOnStop = true
+	if opts.Mode != nil && *opts.Mode == sppb.ExecuteSqlRequest_PLAN {
+		return false, completeOnStop
+	}
+	return true, completeOnStop
+}
+
+func runInNewTransaction(ctx context.Context, client *spanner.Client, stmt spanner.Statement, opts spanner.QueryOptions, mode queryMode, reductRows bool) (*sppb.ResultSet, error) {
+	dmlRowCount, _ := readWriteStatFlags(mode, opts)
 	var rs *sppb.ResultSet
 	switch mode := mode.(type) {
 	case readWrite:
 		_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) (err error) {
-			rs, err = resultset.Materialize(tx.QueryWithOptions(ctx, stmt, opts), reductRows, dml)
+			rs, err = resultset.Materialize(tx.QueryWithOptions(ctx, stmt, opts), reductRows, dmlRowCount)
 			return err
 		})
 		return rs, err
 	case single:
-		return resultset.Materialize(client.Single().WithTimestampBound(mode.TimestampBound).QueryWithOptions(ctx, stmt, opts), reductRows, dml)
+		return resultset.Materialize(client.Single().WithTimestampBound(mode.TimestampBound).QueryWithOptions(ctx, stmt, opts), reductRows, dmlRowCount)
 	case partitionedDML:
 		count, err := client.PartitionedUpdateWithOptions(ctx, stmt, opts)
 		return &sppb.ResultSet{
@@ -490,13 +500,15 @@ func runJqOutput(
 		if err != nil {
 			return err
 		}
-		iter, cleanup, err := jqresult.Execute(jqCode, jqMode, nil, rs, o.RedactRows, false)
+		iter, cleanup, err := jqresult.Execute(jqCode, jqMode, nil, rs, o.RedactRows, false, false)
 		if err != nil {
 			return err
 		}
 		defer cleanup()
 		return jqresult.Print(enc, iter)
 	}
+
+	dmlRowCount, completeOnStop := readWriteStatFlags(mode, opts)
 
 	switch mode := mode.(type) {
 	case readWrite:
@@ -507,7 +519,7 @@ func runJqOutput(
 			if err != nil {
 				return err
 			}
-			return runJqOnRowIter(tx.QueryWithOptions(ctx, stmt, opts), o.RedactRows, jqMode, jqCode, enc, true)
+			return runJqOnRowIter(tx.QueryWithOptions(ctx, stmt, opts), o.RedactRows, jqMode, jqCode, enc, dmlRowCount, completeOnStop)
 		})
 		if err != nil {
 			return err
@@ -520,7 +532,7 @@ func runJqOutput(
 			return err
 		}
 		rowIter := client.Single().WithTimestampBound(mode.TimestampBound).QueryWithOptions(ctx, stmt, opts)
-		return runJqOnRowIter(rowIter, o.RedactRows, jqMode, jqCode, enc, false)
+		return runJqOnRowIter(rowIter, o.RedactRows, jqMode, jqCode, enc, false, false)
 	case partitionedDML:
 		// Eager mode is handled above via runInNewTransaction.
 		return fmt.Errorf("--jq-input-mode=lazy is not supported for partitioned DML")
@@ -535,9 +547,10 @@ func runJqOnRowIter(
 	jqMode jqresult.InputMode,
 	jqCode *gojq.Code,
 	enc encoder,
-	dml bool,
+	dmlRowCount bool,
+	completeOnStop bool,
 ) error {
-	iter, cleanup, err := jqresult.Execute(jqCode, jqMode, rowIter, nil, redactRows, dml)
+	iter, cleanup, err := jqresult.Execute(jqCode, jqMode, rowIter, nil, redactRows, dmlRowCount, completeOnStop)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -173,21 +173,20 @@ func (s single) isQueryMode()         {}
 func (r readWrite) isQueryMode()      {}
 func (p partitionedDML) isQueryMode() {}
 
-// readWriteStatFlags reports whether read-write results should encode exact DML
-// row counts and whether lazy jq must fully consume the RowIterator on cleanup.
-func readWriteStatFlags(mode queryMode, opts spanner.QueryOptions) (dmlRowCount, completeOnStop bool) {
+// dmlRowCountForMode reports whether read-write results should encode exact DML
+// row counts. PLAN mode returns false because execution does not produce a count.
+func dmlRowCountForMode(mode queryMode, opts spanner.QueryOptions) bool {
 	if _, ok := mode.(readWrite); !ok {
-		return false, false
+		return false
 	}
-	completeOnStop = true
 	if opts.Mode != nil && *opts.Mode == sppb.ExecuteSqlRequest_PLAN {
-		return false, completeOnStop
+		return false
 	}
-	return true, completeOnStop
+	return true
 }
 
 func runInNewTransaction(ctx context.Context, client *spanner.Client, stmt spanner.Statement, opts spanner.QueryOptions, mode queryMode, reductRows bool) (*sppb.ResultSet, error) {
-	dmlRowCount, _ := readWriteStatFlags(mode, opts)
+	dmlRowCount := dmlRowCountForMode(mode, opts)
 	var rs *sppb.ResultSet
 	switch mode := mode.(type) {
 	case readWrite:
@@ -491,7 +490,11 @@ func runJqOutput(
 	jqMode jqresult.InputMode,
 	jqCode *gojq.Code,
 ) error {
-	if jqMode == jqresult.InputEager {
+	useEager := jqMode == jqresult.InputEager
+	if _, ok := mode.(readWrite); ok {
+		useEager = true
+	}
+	if useEager {
 		rs, err := runInNewTransaction(ctx, client, stmt, opts, mode, o.RedactRows)
 		if err != nil {
 			return err
@@ -500,7 +503,7 @@ func runJqOutput(
 		if err != nil {
 			return err
 		}
-		iter, cleanup, err := jqresult.Execute(jqCode, jqMode, nil, rs, o.RedactRows, false, false)
+		iter, cleanup, err := jqresult.Execute(jqCode, jqresult.InputEager, nil, rs, o.RedactRows)
 		if err != nil {
 			return err
 		}
@@ -508,33 +511,17 @@ func runJqOutput(
 		return jqresult.Print(enc, iter)
 	}
 
-	dmlRowCount, completeOnStop := readWriteStatFlags(mode, opts)
-
 	switch mode := mode.(type) {
 	case readWrite:
-		var buf bytes.Buffer
-		_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
-			buf.Reset()
-			enc, err := newEncoder(&buf, o.Format, o.CompactOutput, o.JqRawOutput)
-			if err != nil {
-				return err
-			}
-			return runJqOnRowIter(tx.QueryWithOptions(ctx, stmt, opts), o.RedactRows, jqMode, jqCode, enc, dmlRowCount, completeOnStop)
-		})
-		if err != nil {
-			return err
-		}
-		_, err = io.Copy(os.Stdout, &buf)
-		return err
+		panic("read-write jq uses eager materialization")
 	case single:
 		enc, err := newEncoder(os.Stdout, o.Format, o.CompactOutput, o.JqRawOutput)
 		if err != nil {
 			return err
 		}
 		rowIter := client.Single().WithTimestampBound(mode.TimestampBound).QueryWithOptions(ctx, stmt, opts)
-		return runJqOnRowIter(rowIter, o.RedactRows, jqMode, jqCode, enc, false, false)
+		return runJqOnRowIter(rowIter, o.RedactRows, jqCode, enc)
 	case partitionedDML:
-		// Eager mode is handled above via runInNewTransaction.
 		return fmt.Errorf("--jq-input-mode=lazy is not supported for partitioned DML")
 	default:
 		panic(fmt.Sprintf("unknown mode: %T", mode))
@@ -544,13 +531,10 @@ func runJqOutput(
 func runJqOnRowIter(
 	rowIter *spanner.RowIterator,
 	redactRows bool,
-	jqMode jqresult.InputMode,
 	jqCode *gojq.Code,
 	enc encoder,
-	dmlRowCount bool,
-	completeOnStop bool,
 ) error {
-	iter, cleanup, err := jqresult.Execute(jqCode, jqMode, rowIter, nil, redactRows, dmlRowCount, completeOnStop)
+	iter, cleanup, err := jqresult.Execute(jqCode, jqresult.InputLazy, rowIter, nil, redactRows)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/execspansql/jqresult"
 	"github.com/apstndb/execspansql/resultset"
+	"github.com/apstndb/spaniter"
 	"github.com/apstndb/spannerotel/interceptor"
 	svwriter "github.com/apstndb/spanvalue/writer"
 	"github.com/jessevdk/go-flags"
@@ -185,18 +186,25 @@ func dmlRowCountForMode(mode queryMode, opts spanner.QueryOptions) bool {
 	return true
 }
 
+func spaniterStatsOpts(mode queryMode, opts spanner.QueryOptions) []spaniter.Option {
+	if dmlRowCountForMode(mode, opts) {
+		return []spaniter.Option{spaniter.WithStatsEncoding(spaniter.StatsEncodingDMLExact)}
+	}
+	return nil
+}
+
 func runInNewTransaction(ctx context.Context, client *spanner.Client, stmt spanner.Statement, opts spanner.QueryOptions, mode queryMode, reductRows bool) (*sppb.ResultSet, error) {
-	dmlRowCount := dmlRowCountForMode(mode, opts)
+	statOpts := spaniterStatsOpts(mode, opts)
 	var rs *sppb.ResultSet
 	switch mode := mode.(type) {
 	case readWrite:
 		_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) (err error) {
-			rs, err = resultset.Materialize(tx.QueryWithOptions(ctx, stmt, opts), reductRows, dmlRowCount)
+			rs, err = resultset.Materialize(tx.QueryWithOptions(ctx, stmt, opts), reductRows, statOpts...)
 			return err
 		})
 		return rs, err
 	case single:
-		return resultset.Materialize(client.Single().WithTimestampBound(mode.TimestampBound).QueryWithOptions(ctx, stmt, opts), reductRows, dmlRowCount)
+		return resultset.Materialize(client.Single().WithTimestampBound(mode.TimestampBound).QueryWithOptions(ctx, stmt, opts), reductRows, statOpts...)
 	case partitionedDML:
 		count, err := client.PartitionedUpdateWithOptions(ctx, stmt, opts)
 		return &sppb.ResultSet{

--- a/main.go
+++ b/main.go
@@ -4,12 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/apstndb/execspansql/internal"
 	"github.com/apstndb/execspansql/params"
 	"io"
 	"regexp"
-	"slices"
-	"spheric.cloud/xiter"
 	"time"
 
 	"fmt"
@@ -35,12 +32,11 @@ import (
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/execspansql/jqresult"
-	"github.com/apstndb/spaniter"
+	"github.com/apstndb/execspansql/resultset"
 	"github.com/apstndb/spannerotel/interceptor"
 	svwriter "github.com/apstndb/spanvalue/writer"
 	"github.com/jessevdk/go-flags"
 	"github.com/wader/gojq"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func main() {
@@ -182,12 +178,12 @@ func runInNewTransaction(ctx context.Context, client *spanner.Client, stmt spann
 	switch mode := mode.(type) {
 	case readWrite:
 		_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) (err error) {
-			rs, err = consumeRowIterIntoResultSet(tx.QueryWithOptions(ctx, stmt, opts), reductRows)
+			rs, err = resultset.Materialize(tx.QueryWithOptions(ctx, stmt, opts), reductRows)
 			return err
 		})
 		return rs, err
 	case single:
-		return consumeRowIterIntoResultSet(client.Single().WithTimestampBound(mode.TimestampBound).QueryWithOptions(ctx, stmt, opts), reductRows)
+		return resultset.Materialize(client.Single().WithTimestampBound(mode.TimestampBound).QueryWithOptions(ctx, stmt, opts), reductRows)
 	case partitionedDML:
 		count, err := client.PartitionedUpdateWithOptions(ctx, stmt, opts)
 		return &sppb.ResultSet{
@@ -562,33 +558,4 @@ func newEncoder(writer io.Writer, format string, compactOutput bool, rawOutput b
 	default:
 		return nil, fmt.Errorf("unknown format: %s", format)
 	}
-}
-
-// consumeRowIterIntoResultSet construct *spannerpb.ResultSet using *spanner.RowIterator.
-// rowIter must be passed without calling any method, and it will be closed by this function.
-func consumeRowIterIntoResultSet(rowIter *spanner.RowIterator, redactRows bool) (*sppb.ResultSet, error) {
-	if redactRows {
-		result, err := spaniter.DrainRowIterator(rowIter)
-		if err != nil {
-			return nil, err
-		}
-		return jqresult.BuildResultSetFromParts(nil, result.Metadata, result.Stats)
-	}
-
-	var result spaniter.RowIteratorResult
-	rows, err := consumeRowIterIntoListValues(rowIter,
-		spaniter.WithResult(&result),
-	)
-	if err != nil {
-		return nil, err
-	}
-	return jqresult.BuildResultSetFromParts(rows, result.Metadata, result.Stats)
-}
-
-func rowToListValue(r *spanner.Row) *structpb.ListValue {
-	return &structpb.ListValue{Values: slices.Collect(xiter.Map(xiter.Range(0, r.Size()), r.ColumnValue))}
-}
-
-func consumeRowIterIntoListValues(rowIter *spanner.RowIterator, opts ...spaniter.Option) ([]*structpb.ListValue, error) {
-	return xiter.TryCollect(internal.MapNonError(spaniter.RowIteratorSeq(rowIter, opts...), rowToListValue))
 }

--- a/resultset/build.go
+++ b/resultset/build.go
@@ -8,13 +8,21 @@ import (
 
 // FromIteratorResult constructs a ResultSet from materialized rows and drained
 // iterator state. rows may be nil when row values are intentionally redacted.
-func FromIteratorResult(rows []*structpb.ListValue, result spaniter.RowIteratorResult) (*sppb.ResultSet, error) {
+// When dml is true, stats are encoded with ResultSetStatsForDML so standard DML
+// row_count_exact:0 is preserved.
+func FromIteratorResult(rows []*structpb.ListValue, result spaniter.RowIteratorResult, dml bool) (*sppb.ResultSet, error) {
 	out := &sppb.ResultSet{
 		Rows:     rows,
 		Metadata: result.Metadata,
 	}
 
-	resultStats, err := result.Stats.ResultSetStats()
+	var resultStats *sppb.ResultSetStats
+	var err error
+	if dml {
+		resultStats, err = result.Stats.ResultSetStatsForDML()
+	} else {
+		resultStats, err = result.Stats.ResultSetStats()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/resultset/build.go
+++ b/resultset/build.go
@@ -6,17 +6,9 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func statsEncoding(dmlRowCount bool) spaniter.StatsEncoding {
-	if dmlRowCount {
-		return spaniter.StatsEncodingDMLExact
-	}
-	return spaniter.StatsEncodingDefault
-}
-
 // FromIteratorResult constructs a ResultSet from materialized rows and drained
 // iterator state. rows may be nil when row values are intentionally redacted.
-// When dmlRowCount is true, stats use DML exact row-count encoding. PLAN mode
-// callers must pass false.
-func FromIteratorResult(rows []*structpb.ListValue, result spaniter.RowIteratorResult, dmlRowCount bool) (*sppb.ResultSet, error) {
-	return result.ResultSet(rows, statsEncoding(dmlRowCount))
+// Stats encoding comes from spaniter drain options such as WithStatsEncoding.
+func FromIteratorResult(rows []*structpb.ListValue, result spaniter.RowIteratorResult) (*sppb.ResultSet, error) {
+	return result.ResultSet(rows)
 }

--- a/resultset/build.go
+++ b/resultset/build.go
@@ -6,26 +6,17 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+func statsEncoding(dmlRowCount bool) spaniter.StatsEncoding {
+	if dmlRowCount {
+		return spaniter.StatsEncodingDMLExact
+	}
+	return spaniter.StatsEncodingDefault
+}
+
 // FromIteratorResult constructs a ResultSet from materialized rows and drained
 // iterator state. rows may be nil when row values are intentionally redacted.
-// When dmlRowCount is true, stats are encoded with ResultSetStatsForDML so standard DML
-// row_count_exact:0 is preserved. PLAN mode callers must pass false.
+// When dmlRowCount is true, stats use DML exact row-count encoding. PLAN mode
+// callers must pass false.
 func FromIteratorResult(rows []*structpb.ListValue, result spaniter.RowIteratorResult, dmlRowCount bool) (*sppb.ResultSet, error) {
-	out := &sppb.ResultSet{
-		Rows:     rows,
-		Metadata: result.Metadata,
-	}
-
-	var resultStats *sppb.ResultSetStats
-	var err error
-	if dmlRowCount {
-		resultStats, err = result.Stats.ResultSetStatsForDML()
-	} else {
-		resultStats, err = result.Stats.ResultSetStats()
-	}
-	if err != nil {
-		return nil, err
-	}
-	out.Stats = resultStats
-	return out, nil
+	return result.ResultSet(rows, statsEncoding(dmlRowCount))
 }

--- a/resultset/build.go
+++ b/resultset/build.go
@@ -1,0 +1,23 @@
+package resultset
+
+import (
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spaniter"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// FromIteratorResult constructs a ResultSet from materialized rows and drained
+// iterator state. rows may be nil when row values are intentionally redacted.
+func FromIteratorResult(rows []*structpb.ListValue, result spaniter.RowIteratorResult) (*sppb.ResultSet, error) {
+	out := &sppb.ResultSet{
+		Rows:     rows,
+		Metadata: result.Metadata,
+	}
+
+	resultStats, err := result.Stats.ResultSetStats()
+	if err != nil {
+		return nil, err
+	}
+	out.Stats = resultStats
+	return out, nil
+}

--- a/resultset/build.go
+++ b/resultset/build.go
@@ -8,9 +8,9 @@ import (
 
 // FromIteratorResult constructs a ResultSet from materialized rows and drained
 // iterator state. rows may be nil when row values are intentionally redacted.
-// When dml is true, stats are encoded with ResultSetStatsForDML so standard DML
-// row_count_exact:0 is preserved.
-func FromIteratorResult(rows []*structpb.ListValue, result spaniter.RowIteratorResult, dml bool) (*sppb.ResultSet, error) {
+// When dmlRowCount is true, stats are encoded with ResultSetStatsForDML so standard DML
+// row_count_exact:0 is preserved. PLAN mode callers must pass false.
+func FromIteratorResult(rows []*structpb.ListValue, result spaniter.RowIteratorResult, dmlRowCount bool) (*sppb.ResultSet, error) {
 	out := &sppb.ResultSet{
 		Rows:     rows,
 		Metadata: result.Metadata,
@@ -18,7 +18,7 @@ func FromIteratorResult(rows []*structpb.ListValue, result spaniter.RowIteratorR
 
 	var resultStats *sppb.ResultSetStats
 	var err error
-	if dml {
+	if dmlRowCount {
 		resultStats, err = result.Stats.ResultSetStatsForDML()
 	} else {
 		resultStats, err = result.Stats.ResultSetStats()

--- a/resultset/doc.go
+++ b/resultset/doc.go
@@ -1,0 +1,6 @@
+// Package resultset drains Cloud Spanner row iterators into protobuf ResultSets.
+//
+// It composes [github.com/apstndb/spaniter] for iterator lifecycle and stats
+// conversion. Callers that need jq-shaped maps should use
+// [github.com/apstndb/execspansql/jqresult] on top of the returned ResultSet.
+package resultset

--- a/resultset/materialize.go
+++ b/resultset/materialize.go
@@ -12,7 +12,8 @@ import (
 // Materialize drains rowIter and returns a protobuf ResultSet.
 // rowIter must not have been read yet; Materialize owns and stops it.
 // When redact is true, row values are omitted but metadata and stats are preserved.
-func Materialize(rowIter *spanner.RowIterator, redact bool) (*sppb.ResultSet, error) {
+// When dml is true, stats use ResultSetStatsForDML for standard DML row counts.
+func Materialize(rowIter *spanner.RowIterator, redact bool, dml bool) (*sppb.ResultSet, error) {
 	if rowIter == nil {
 		return nil, errors.New("nil row iterator")
 	}
@@ -21,7 +22,7 @@ func Materialize(rowIter *spanner.RowIterator, redact bool) (*sppb.ResultSet, er
 		if err != nil {
 			return nil, err
 		}
-		return FromIteratorResult(nil, *result)
+		return FromIteratorResult(nil, *result, dml)
 	}
 
 	var result spaniter.RowIteratorResult
@@ -29,7 +30,7 @@ func Materialize(rowIter *spanner.RowIterator, redact bool) (*sppb.ResultSet, er
 	if err != nil {
 		return nil, err
 	}
-	return FromIteratorResult(rows, result)
+	return FromIteratorResult(rows, result, dml)
 }
 
 // CollectListValues drains rowIter into protobuf row values.

--- a/resultset/materialize.go
+++ b/resultset/materialize.go
@@ -12,8 +12,9 @@ import (
 // Materialize drains rowIter and returns a protobuf ResultSet.
 // rowIter must not have been read yet; Materialize owns and stops it.
 // When redact is true, row values are omitted but metadata and stats are preserved.
-// When dml is true, stats use ResultSetStatsForDML for standard DML row counts.
-func Materialize(rowIter *spanner.RowIterator, redact bool, dml bool) (*sppb.ResultSet, error) {
+// When dmlRowCount is true, stats use ResultSetStatsForDML for standard DML row counts.
+// PLAN mode callers must pass false.
+func Materialize(rowIter *spanner.RowIterator, redact bool, dmlRowCount bool) (*sppb.ResultSet, error) {
 	if rowIter == nil {
 		return nil, errors.New("nil row iterator")
 	}
@@ -22,7 +23,7 @@ func Materialize(rowIter *spanner.RowIterator, redact bool, dml bool) (*sppb.Res
 		if err != nil {
 			return nil, err
 		}
-		return FromIteratorResult(nil, *result, dml)
+		return FromIteratorResult(nil, *result, dmlRowCount)
 	}
 
 	var result spaniter.RowIteratorResult
@@ -30,7 +31,7 @@ func Materialize(rowIter *spanner.RowIterator, redact bool, dml bool) (*sppb.Res
 	if err != nil {
 		return nil, err
 	}
-	return FromIteratorResult(rows, result, dml)
+	return FromIteratorResult(rows, result, dmlRowCount)
 }
 
 // CollectListValues drains rowIter into protobuf row values.

--- a/resultset/materialize.go
+++ b/resultset/materialize.go
@@ -1,0 +1,46 @@
+package resultset
+
+import (
+	"errors"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spaniter"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Materialize drains rowIter and returns a protobuf ResultSet.
+// rowIter must not have been read yet; Materialize owns and stops it.
+// When redact is true, row values are omitted but metadata and stats are preserved.
+func Materialize(rowIter *spanner.RowIterator, redact bool) (*sppb.ResultSet, error) {
+	if rowIter == nil {
+		return nil, errors.New("nil row iterator")
+	}
+	if redact {
+		result, err := spaniter.DrainRowIterator(rowIter)
+		if err != nil {
+			return nil, err
+		}
+		return FromIteratorResult(nil, *result)
+	}
+
+	var result spaniter.RowIteratorResult
+	rows, err := CollectListValues(rowIter, spaniter.WithResult(&result))
+	if err != nil {
+		return nil, err
+	}
+	return FromIteratorResult(rows, result)
+}
+
+// CollectListValues drains rowIter into protobuf row values.
+// rowIter must not have been read yet unless opts configure partial consumption.
+func CollectListValues(rowIter *spanner.RowIterator, opts ...spaniter.Option) ([]*structpb.ListValue, error) {
+	var rows []*structpb.ListValue
+	for row, err := range spaniter.RowIteratorSeq(rowIter, opts...) {
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, RowToListValue(row))
+	}
+	return rows, nil
+}

--- a/resultset/materialize.go
+++ b/resultset/materialize.go
@@ -12,26 +12,26 @@ import (
 // Materialize drains rowIter and returns a protobuf ResultSet.
 // rowIter must not have been read yet; Materialize owns and stops it.
 // When redact is true, row values are omitted but metadata and stats are preserved.
-// When dmlRowCount is true, stats use ResultSetStatsForDML for standard DML row counts.
-// PLAN mode callers must pass false.
-func Materialize(rowIter *spanner.RowIterator, redact bool, dmlRowCount bool) (*sppb.ResultSet, error) {
+// Stats encoding is configured via spaniter options such as WithStatsEncoding.
+func Materialize(rowIter *spanner.RowIterator, redact bool, opts ...spaniter.Option) (*sppb.ResultSet, error) {
 	if rowIter == nil {
 		return nil, errors.New("nil row iterator")
 	}
 	if redact {
-		result, err := spaniter.DrainRowIterator(rowIter)
+		result, err := spaniter.DrainRowIterator(rowIter, opts...)
 		if err != nil {
 			return nil, err
 		}
-		return FromIteratorResult(nil, *result, dmlRowCount)
+		return FromIteratorResult(nil, *result)
 	}
 
 	var result spaniter.RowIteratorResult
-	rows, err := CollectListValues(rowIter, spaniter.WithResult(&result))
+	allOpts := append(append([]spaniter.Option(nil), opts...), spaniter.WithResult(&result))
+	rows, err := CollectListValues(rowIter, allOpts...)
 	if err != nil {
 		return nil, err
 	}
-	return FromIteratorResult(rows, result, dmlRowCount)
+	return FromIteratorResult(rows, result)
 }
 
 // CollectListValues drains rowIter into protobuf row values.

--- a/resultset/resultset_test.go
+++ b/resultset/resultset_test.go
@@ -10,7 +10,7 @@ import (
 func TestMaterializeNilRowIterator(t *testing.T) {
 	t.Parallel()
 
-	_, err := Materialize(nil, false)
+	_, err := Materialize(nil, false, false)
 	if err == nil {
 		t.Fatal("error = nil, want nil row iterator error")
 	}
@@ -31,7 +31,7 @@ func TestCollectListValuesNilRowIterator(t *testing.T) {
 func TestFromIteratorResultEmptyStats(t *testing.T) {
 	t.Parallel()
 
-	got, err := FromIteratorResult(nil, spaniter.RowIteratorResult{})
+	got, err := FromIteratorResult(nil, spaniter.RowIteratorResult{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,11 +44,46 @@ func TestFromIteratorResultPreservesMetadata(t *testing.T) {
 	t.Parallel()
 
 	md := &sppb.ResultSetMetadata{}
-	got, err := FromIteratorResult(nil, spaniter.RowIteratorResult{Metadata: md})
+	got, err := FromIteratorResult(nil, spaniter.RowIteratorResult{Metadata: md}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got.Metadata != md {
 		t.Fatal("metadata was not preserved")
+	}
+}
+
+func TestFromIteratorResultDMLZeroRowCount(t *testing.T) {
+	t.Parallel()
+
+	got, err := FromIteratorResult(nil, spaniter.RowIteratorResult{
+		Stats: spaniter.Stats{RowCount: 0},
+	}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Stats == nil {
+		t.Fatal("Stats = nil, want DML zero row count stats")
+	}
+	exact, ok := got.Stats.GetRowCount().(*sppb.ResultSetStats_RowCountExact)
+	if !ok {
+		t.Fatalf("RowCount type = %T, want RowCountExact", got.Stats.GetRowCount())
+	}
+	if exact.RowCountExact != 0 {
+		t.Fatalf("RowCountExact = %d, want 0", exact.RowCountExact)
+	}
+}
+
+func TestFromIteratorResultQueryZeroRowCountOmitsStats(t *testing.T) {
+	t.Parallel()
+
+	got, err := FromIteratorResult(nil, spaniter.RowIteratorResult{
+		Stats: spaniter.Stats{RowCount: 0},
+	}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Stats != nil {
+		t.Fatalf("Stats = %v, want nil for query zero row count", got.Stats)
 	}
 }

--- a/resultset/resultset_test.go
+++ b/resultset/resultset_test.go
@@ -1,0 +1,54 @@
+package resultset
+
+import (
+	"testing"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spaniter"
+)
+
+func TestMaterializeNilRowIterator(t *testing.T) {
+	t.Parallel()
+
+	_, err := Materialize(nil, false)
+	if err == nil {
+		t.Fatal("error = nil, want nil row iterator error")
+	}
+}
+
+func TestCollectListValuesNilRowIterator(t *testing.T) {
+	t.Parallel()
+
+	rows, err := CollectListValues(nil)
+	if err == nil {
+		t.Fatal("error = nil, want error from nil row iterator")
+	}
+	if rows != nil {
+		t.Fatalf("rows = %v, want nil", rows)
+	}
+}
+
+func TestFromIteratorResultEmptyStats(t *testing.T) {
+	t.Parallel()
+
+	got, err := FromIteratorResult(nil, spaniter.RowIteratorResult{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Stats != nil {
+		t.Fatalf("Stats = %v, want nil", got.Stats)
+	}
+}
+
+func TestFromIteratorResultPreservesMetadata(t *testing.T) {
+	t.Parallel()
+
+	md := &sppb.ResultSetMetadata{}
+	got, err := FromIteratorResult(nil, spaniter.RowIteratorResult{Metadata: md})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata != md {
+		t.Fatal("metadata was not preserved")
+	}
+}

--- a/resultset/resultset_test.go
+++ b/resultset/resultset_test.go
@@ -10,7 +10,7 @@ import (
 func TestMaterializeNilRowIterator(t *testing.T) {
 	t.Parallel()
 
-	_, err := Materialize(nil, false, false)
+	_, err := Materialize(nil, false)
 	if err == nil {
 		t.Fatal("error = nil, want nil row iterator error")
 	}
@@ -31,7 +31,7 @@ func TestCollectListValuesNilRowIterator(t *testing.T) {
 func TestFromIteratorResultEmptyStats(t *testing.T) {
 	t.Parallel()
 
-	got, err := FromIteratorResult(nil, spaniter.RowIteratorResult{}, false)
+	got, err := FromIteratorResult(nil, spaniter.RowIteratorResult{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,46 +44,11 @@ func TestFromIteratorResultPreservesMetadata(t *testing.T) {
 	t.Parallel()
 
 	md := &sppb.ResultSetMetadata{}
-	got, err := FromIteratorResult(nil, spaniter.RowIteratorResult{Metadata: md}, false)
+	got, err := FromIteratorResult(nil, spaniter.RowIteratorResult{Metadata: md})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got.Metadata != md {
 		t.Fatal("metadata was not preserved")
-	}
-}
-
-func TestFromIteratorResultDMLZeroRowCount(t *testing.T) {
-	t.Parallel()
-
-	got, err := FromIteratorResult(nil, spaniter.RowIteratorResult{
-		Stats: spaniter.Stats{RowCount: 0},
-	}, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.Stats == nil {
-		t.Fatal("Stats = nil, want DML zero row count stats")
-	}
-	exact, ok := got.Stats.GetRowCount().(*sppb.ResultSetStats_RowCountExact)
-	if !ok {
-		t.Fatalf("RowCount type = %T, want RowCountExact", got.Stats.GetRowCount())
-	}
-	if exact.RowCountExact != 0 {
-		t.Fatalf("RowCountExact = %d, want 0", exact.RowCountExact)
-	}
-}
-
-func TestFromIteratorResultQueryZeroRowCountOmitsStats(t *testing.T) {
-	t.Parallel()
-
-	got, err := FromIteratorResult(nil, spaniter.RowIteratorResult{
-		Stats: spaniter.Stats{RowCount: 0},
-	}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.Stats != nil {
-		t.Fatalf("Stats = %v, want nil for query zero row count", got.Stats)
 	}
 }

--- a/resultset/row.go
+++ b/resultset/row.go
@@ -1,0 +1,14 @@
+package resultset
+
+import (
+	"slices"
+	"spheric.cloud/xiter"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// RowToListValue converts a Spanner row to structpb.ListValue.
+func RowToListValue(r *spanner.Row) *structpb.ListValue {
+	return &structpb.ListValue{Values: slices.Collect(xiter.Map(xiter.Range(0, r.Size()), r.ColumnValue))}
+}


### PR DESCRIPTION
## Summary

- Bump `github.com/apstndb/spaniter` to **v0.3.0** and adopt `WithStatsEncoding`, `RowIteratorResult.StatsProto` / `ResultSet`, and `PullRowIteratorSeq`.
- Add `resultset` package for RowIterator → `*sppb.ResultSet` materialization (`Materialize`, `FromIteratorResult`, `CollectListValues`, `RowToListValue`).
- Slim `jqresult` to jq-specific concerns: protojson maps, lazy/eager gojq pipeline, `RowToJSON`.
- Drive lazy `RowIter` through `PullRowIteratorSeq` with `WithResult`; `Stop()` stops the pull sequence when started, otherwise stops the raw iterator directly.
- Coerce read-write jq to eager materialization before jq so DML executes even when the filter ignores input (for example `true`). Lazy jq remains read-only only.
- Pass `WithStatsEncoding(DMLExact)` for executed read-write DML via `spaniterStatsOpts`; PLAN mode keeps default encoding so `row_count_exact: 0` is not fabricated.
- Propagate terminal iterator errors from `PullRowIteratorSeq` through lazy `RowIter`.

## Test plan

- [x] `go test ./...`
- [x] `go test -run TestWithCloudSpannerEmulator .` (emulator)
- [x] read-write DML preserves `rowCountExact: "0"` for zero-row UPDATE
- [x] PLAN DML materialization omits fabricated `rowCountExact`
- [x] jqresult lazy unit tests and resultset / protojson DML stats tests