### PR TITLE
Replace go-spannulls with spanvalue/gcvctor for typed NULL params

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.25.0
 require (
 	cloud.google.com/go/spanner v1.84.1
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.24.0
-	github.com/apstndb/go-spannulls v0.0.0-20241108213137-ec54277850d4
 	github.com/apstndb/gsqlsep v0.0.0-20240823174243-432be37d515a
 	github.com/apstndb/memebridge v0.6.0
 	github.com/apstndb/spanemuboost v0.4.6

--- a/go.sum
+++ b/go.sum
@@ -650,8 +650,6 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/apstndb/go-spannulls v0.0.0-20241108213137-ec54277850d4 h1:WfWmn7N+kNxe5YYh1Uoy/FG2CzPpuxCkYQPovjxrDSk=
-github.com/apstndb/go-spannulls v0.0.0-20241108213137-ec54277850d4/go.mod h1:4Z/Xh/qZ1KSd0VDUI9n+c4fJqtscegWOOt4MAz14SWQ=
 github.com/apstndb/gsqlsep v0.0.0-20240823174243-432be37d515a h1:9rutREITQVQSkSt2uoRr8ap6JA+k5i7NL1zRmJe621g=
 github.com/apstndb/gsqlsep v0.0.0-20240823174243-432be37d515a/go.mod h1:NQogaK8AOkyzXEXMqGvc6hV0SKO8cUkcqqXJimyvTlw=
 github.com/apstndb/memebridge v0.6.0 h1:45uu/RFF63u5vJ+d8HT4PvOfotm1cV4eEveWFwGvElI=

--- a/params/params.go
+++ b/params/params.go
@@ -1,16 +1,17 @@
 package params
 
 import (
-	"cloud.google.com/go/spanner"
 	"fmt"
+
+	"cloud.google.com/go/spanner"
 	"github.com/apstndb/execspansql/internal"
-	"github.com/apstndb/go-spannulls"
 	"github.com/apstndb/memebridge"
+	"github.com/apstndb/spanvalue/gcvctor"
 	"github.com/cloudspannerecosystem/memefish"
 	"github.com/cloudspannerecosystem/memefish/ast"
 )
 
-// generateParams returns map for spanner.Statement.Params.
+// GenerateParams returns map for spanner.Statement.Params.
 // All values of map are spanner.GenericColumnValue.
 func GenerateParams(ss map[string]string, permitType bool) (map[string]interface{}, error) {
 	return internal.TryMapMap(ss, func(k, v string) (interface{}, error) {
@@ -56,5 +57,5 @@ func astTypeToGenericColumnValue(t ast.Type) (spanner.GenericColumnValue, error)
 	if err != nil {
 		return spanner.GenericColumnValue{}, err
 	}
-	return spannulls.NullGenericColumnValueFromType(typ), nil
+	return gcvctor.NullOf(typ), nil
 }

--- a/params/params_test.go
+++ b/params/params_test.go
@@ -87,9 +87,7 @@ func TestGenerateParams(t *testing.T) {
 							},
 						}},
 					},
-					Value: structpb.NewListValue(&structpb.ListValue{
-						Values: []*structpb.Value{structpb.NewNullValue()},
-					}),
+					Value: structpb.NewNullValue(),
 				},
 				"string_array_type": spanner.GenericColumnValue{
 					Type: &sppb.Type{


### PR DESCRIPTION
## Summary
- Remove direct dependency on go-spannulls.
- Use `gcvctor.NullOf` from spanvalue for PLAN-mode typed NULL parameters.
- STRUCT NULL is now a scalar NULL, matching current Spanner behavior.

## Test plan
- [x] `go test ./params/...`


Made with [Cursor](https://cursor.com)