### PR TITLE
Add --param-file for YAML/JSON query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Application Options:
   -r, --raw-output                             (--raw-output of jq)
       --filter-file=                           (--from-file of jq)
       --param=                                 [name]:[Cloud Spanner type(PLAN only) or literal]
+      --param-file=                            YAML or JSON file of query parameters
       --log-grpc                               Show gRPC logs
       --experimental-trace-project=
       --enable-partitioned-dml                 Execute DML statement using Partitioned DML
@@ -78,7 +79,7 @@ There are examples omitting some required options.
 Many Cloud Spanner clients don't support parameter.
 Without modifications, query which have parameters are impossible to execute and query whose parameters' types are `STRUCT` or `ARRAY` are impossible to show query plans.
 
-execspansql supports query parameters.
+execspansql supports query parameters via repeated `--param name:value` flags or a `--param-file` (YAML or JSON). When both are given, `--param` overrides entries from the file.
 
 #### PLAN with complex typed parameters
 
@@ -93,6 +94,22 @@ $ execspansql ${DATABASE_ID} --query-mode=PLAN \
 $ execspansql ${DATABASE_ID} --query-mode=PLAN \
               --sql='SELECT @str.*' \
               --param='str:STRUCT<FirstName STRING, LastName STRING>'
+```
+
+#### Parameters from a file
+
+`--param-file` accepts YAML or JSON (`.json` extension selects JSON; otherwise YAML). Values are the same type/literal strings used with `--param`.
+
+```yaml
+# params.yaml
+arr: ARRAY<STRING>
+names: '[STRUCT<FirstName STRING, LastName STRING>("John", "Doe"), ("Mary", "Sue")]'
+```
+
+```
+$ execspansql ${DATABASE_ID} --query-mode=PROFILE \
+              --sql='SELECT * FROM UNNEST(@arr) WITH OFFSET' \
+              --param-file=params.yaml
 ```
 
 #### PROFILE with complex typed parameterized values 

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ type opts struct {
 	JqFromFile           string            `long:"filter-file" description:"(--from-file of jq)"`
 	JqInputMode          string            `long:"jq-input-mode" description:"How query rows are passed to jq (json/yaml only): eager (full ResultSet), lazy (JQValue root)." default:"eager" choice:"eager" choice:"lazy"`
 	Param                map[string]string `long:"param" description:"[name]:[Cloud Spanner type(PLAN only) or literal]"`
+	ParamFile            string            `long:"param-file" description:"YAML or JSON file of query parameters (name to type/literal string)"`
 	LogGrpc              bool              `long:"log-grpc" description:"Show gRPC logs"`
 	TraceProject         string            `long:"experimental-trace-project"`
 	EnablePartitionedDML bool              `long:"enable-partitioned-dml" description:"Execute DML statement using Partitioned DML"`
@@ -86,6 +87,14 @@ type opts struct {
 		Strong        bool   `long:"strong" description:"Perform a strong query."`
 		ReadTimestamp string `long:"read-timestamp" description:"Perform a query at the given timestamp. (micro-seconds precision)" value-name:"TIMESTAMP"`
 	} `group:"Timestamp Bound"`
+}
+
+func (o opts) mergedParams() (map[string]string, error) {
+	fileParams, err := params.LoadParamFile(o.ParamFile)
+	if err != nil {
+		return nil, err
+	}
+	return params.MergeParams(fileParams, o.Param), nil
 }
 
 func processFlags() (o opts, err error) {
@@ -310,7 +319,11 @@ func _main() error {
 	}
 	defer client.Close()
 
-	paramMap, err := params.GenerateParams(o.Param, mode == sppb.ExecuteSqlRequest_PLAN)
+	paramStrMap, err := o.mergedParams()
+	if err != nil {
+		return err
+	}
+	paramMap, err := params.GenerateParams(paramStrMap, mode == sppb.ExecuteSqlRequest_PLAN)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -90,6 +90,9 @@ type opts struct {
 }
 
 func (o opts) mergedParams() (map[string]string, error) {
+	if o.ParamFile == "" {
+		return o.Param, nil
+	}
 	fileParams, err := params.LoadParamFile(o.ParamFile)
 	if err != nil {
 		return nil, err

--- a/params/load.go
+++ b/params/load.go
@@ -38,6 +38,9 @@ func LoadParamFile(path string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(bytes.TrimSpace(b)) == 0 {
+		return nil, nil
+	}
 	var raw map[string]any
 	switch strings.ToLower(filepath.Ext(path)) {
 	case ".json":

--- a/params/load.go
+++ b/params/load.go
@@ -63,23 +63,9 @@ func paramFileValueToString(v any) (string, error) {
 		}
 		return "FALSE", nil
 	case float64:
-		s := fmt.Sprintf("%g", x)
-		if s == "NaN" || s == "+Inf" || s == "-Inf" {
-			return s, nil
-		}
-		if !strings.ContainsAny(s, ".eE") {
-			s += ".0"
-		}
-		return s, nil
+		return formatParamFloat(x), nil
 	case float32:
-		s := fmt.Sprintf("%g", x)
-		if s == "NaN" || s == "+Inf" || s == "-Inf" {
-			return s, nil
-		}
-		if !strings.ContainsAny(s, ".eE") {
-			s += ".0"
-		}
-		return s, nil
+		return formatParamFloat(float64(x)), nil
 	case time.Time:
 		return fmt.Sprintf("TIMESTAMP %q", x.Format(time.RFC3339Nano)), nil
 	case []any, map[string]any, map[any]any:
@@ -89,9 +75,26 @@ func paramFileValueToString(v any) (string, error) {
 	}
 }
 
+func formatParamFloat(x float64) string {
+	s := fmt.Sprintf("%g", x)
+	if s == "NaN" || s == "+Inf" || s == "-Inf" {
+		return s
+	}
+	if !strings.ContainsAny(s, ".eE") {
+		s += ".0"
+	}
+	return s
+}
+
 // MergeParams returns file params with cli params overriding on name conflict.
 func MergeParams(file, cli map[string]string) map[string]string {
-	out := make(map[string]string)
+	if len(file) == 0 {
+		return cli
+	}
+	if len(cli) == 0 {
+		return file
+	}
+	out := make(map[string]string, len(file)+len(cli))
 	maps.Copy(out, file)
 	maps.Copy(out, cli)
 	return out

--- a/params/load.go
+++ b/params/load.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -75,6 +76,20 @@ func paramFileValueToString(v any) (string, error) {
 			return "TRUE", nil
 		}
 		return "FALSE", nil
+	case float64:
+		s := fmt.Sprintf("%g", x)
+		if !strings.ContainsAny(s, ".eE") {
+			s += ".0"
+		}
+		return s, nil
+	case float32:
+		s := fmt.Sprintf("%g", x)
+		if !strings.ContainsAny(s, ".eE") {
+			s += ".0"
+		}
+		return s, nil
+	case time.Time:
+		return fmt.Sprintf("TIMESTAMP %q", x.Format(time.RFC3339Nano)), nil
 	case []any, map[string]any, map[any]any:
 		return "", fmt.Errorf("arrays and maps must be specified as string literals (e.g., '[1, 2, 3]'), got %T", v)
 	default:

--- a/params/load.go
+++ b/params/load.go
@@ -56,12 +56,9 @@ func LoadParamFile(path string) (map[string]string, error) {
 	}
 	out := make(map[string]string, len(raw))
 	for k, v := range raw {
-		if v == nil {
-			continue
-		}
 		s, err := paramFileValueToString(v)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parameter %q: %w", k, err)
 		}
 		out[k] = s
 	}
@@ -70,6 +67,8 @@ func LoadParamFile(path string) (map[string]string, error) {
 
 func paramFileValueToString(v any) (string, error) {
 	switch x := v.(type) {
+	case nil:
+		return "", fmt.Errorf("untyped null values are not supported; use a typed null expression like 'CAST(NULL AS TYPE)' or a type name (PLAN mode only)")
 	case string:
 		return x, nil
 	case json.Number:

--- a/params/load.go
+++ b/params/load.go
@@ -36,18 +36,47 @@ func LoadParamFile(path string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	out := make(map[string]string)
+	var raw map[string]any
 	switch strings.ToLower(filepath.Ext(path)) {
 	case ".json":
-		if err := json.Unmarshal(b, &out); err != nil {
+		dec := json.NewDecoder(strings.NewReader(string(b)))
+		dec.UseNumber()
+		if err := dec.Decode(&raw); err != nil {
 			return nil, fmt.Errorf("parse param file as JSON: %w", err)
 		}
 	default:
-		if err := yaml.Unmarshal(b, &out); err != nil {
+		if err := yaml.Unmarshal(b, &raw); err != nil {
 			return nil, fmt.Errorf("parse param file as YAML: %w", err)
 		}
 	}
+	out := make(map[string]string, len(raw))
+	for k, v := range raw {
+		if v == nil {
+			continue
+		}
+		s, err := paramFileValueToString(v)
+		if err != nil {
+			return nil, err
+		}
+		out[k] = s
+	}
 	return out, nil
+}
+
+func paramFileValueToString(v any) (string, error) {
+	switch x := v.(type) {
+	case string:
+		return x, nil
+	case json.Number:
+		return x.String(), nil
+	case bool:
+		if x {
+			return "TRUE", nil
+		}
+		return "FALSE", nil
+	default:
+		return fmt.Sprintf("%v", x), nil
+	}
 }
 
 // MergeParams returns file params with cli params overriding on name conflict.

--- a/params/load.go
+++ b/params/load.go
@@ -1,6 +1,7 @@
 package params
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -39,7 +40,7 @@ func LoadParamFile(path string) (map[string]string, error) {
 	var raw map[string]any
 	switch strings.ToLower(filepath.Ext(path)) {
 	case ".json":
-		dec := json.NewDecoder(strings.NewReader(string(b)))
+		dec := json.NewDecoder(bytes.NewReader(b))
 		dec.UseNumber()
 		if err := dec.Decode(&raw); err != nil {
 			return nil, fmt.Errorf("parse param file as JSON: %w", err)
@@ -74,6 +75,8 @@ func paramFileValueToString(v any) (string, error) {
 			return "TRUE", nil
 		}
 		return "FALSE", nil
+	case []any, map[string]any, map[any]any:
+		return "", fmt.Errorf("arrays and maps must be specified as string literals (e.g., '[1, 2, 3]'), got %T", v)
 	default:
 		return fmt.Sprintf("%v", x), nil
 	}

--- a/params/load.go
+++ b/params/load.go
@@ -13,22 +13,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// ParseParamFlags parses repeated --param name:value flags.
-func ParseParamFlags(ss []string) (map[string]string, error) {
-	if len(ss) == 0 {
-		return nil, nil
-	}
-	out := make(map[string]string, len(ss))
-	for _, s := range ss {
-		name, value, ok := strings.Cut(s, ":")
-		if !ok || name == "" {
-			return nil, fmt.Errorf("invalid --param %q: expected name:value", s)
-		}
-		out[name] = value
-	}
-	return out, nil
-}
-
 // LoadParamFile loads param name→literal/type strings from a YAML or JSON file.
 func LoadParamFile(path string) (map[string]string, error) {
 	if path == "" {

--- a/params/load.go
+++ b/params/load.go
@@ -81,12 +81,18 @@ func paramFileValueToString(v any) (string, error) {
 		return "FALSE", nil
 	case float64:
 		s := fmt.Sprintf("%g", x)
+		if s == "NaN" || s == "+Inf" || s == "-Inf" {
+			return s, nil
+		}
 		if !strings.ContainsAny(s, ".eE") {
 			s += ".0"
 		}
 		return s, nil
 	case float32:
 		s := fmt.Sprintf("%g", x)
+		if s == "NaN" || s == "+Inf" || s == "-Inf" {
+			return s, nil
+		}
 		if !strings.ContainsAny(s, ".eE") {
 			s += ".0"
 		}

--- a/params/load.go
+++ b/params/load.go
@@ -1,0 +1,59 @@
+package params
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ParseParamFlags parses repeated --param name:value flags.
+func ParseParamFlags(ss []string) (map[string]string, error) {
+	if len(ss) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(ss))
+	for _, s := range ss {
+		name, value, ok := strings.Cut(s, ":")
+		if !ok || name == "" {
+			return nil, fmt.Errorf("invalid --param %q: expected name:value", s)
+		}
+		out[name] = value
+	}
+	return out, nil
+}
+
+// LoadParamFile loads param name→literal/type strings from a YAML or JSON file.
+func LoadParamFile(path string) (map[string]string, error) {
+	if path == "" {
+		return nil, nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]string)
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".json":
+		if err := json.Unmarshal(b, &out); err != nil {
+			return nil, fmt.Errorf("parse param file as JSON: %w", err)
+		}
+	default:
+		if err := yaml.Unmarshal(b, &out); err != nil {
+			return nil, fmt.Errorf("parse param file as YAML: %w", err)
+		}
+	}
+	return out, nil
+}
+
+// MergeParams returns file params with cli params overriding on name conflict.
+func MergeParams(file, cli map[string]string) map[string]string {
+	out := make(map[string]string)
+	maps.Copy(out, file)
+	maps.Copy(out, cli)
+	return out
+}

--- a/params/load_test.go
+++ b/params/load_test.go
@@ -104,6 +104,14 @@ func TestLoadParamFile(t *testing.T) {
 	if len(got) != 0 {
 		t.Fatalf("expected empty map for empty file, got %v", got)
 	}
+
+	nullPath := filepath.Join(dir, "params-null.yaml")
+	if err := os.WriteFile(nullPath, []byte("x: null\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadParamFile(nullPath); err == nil {
+		t.Fatal("expected error for untyped null in param file")
+	}
 }
 
 func TestMergeParams(t *testing.T) {

--- a/params/load_test.go
+++ b/params/load_test.go
@@ -56,14 +56,19 @@ func TestLoadParamFile(t *testing.T) {
 	}
 
 	yamlScalarsPath := filepath.Join(dir, "params-scalars.yaml")
-	if err := os.WriteFile(yamlScalarsPath, []byte("id: 123\nenabled: true\n"), 0o644); err != nil {
+	if err := os.WriteFile(yamlScalarsPath, []byte("id: 123\nenabled: true\nprice: 1.0\ncreated_at: 2023-01-01T00:00:00Z\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	got, err = LoadParamFile(yamlScalarsPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantScalars := map[string]string{"id": "123", "enabled": "TRUE"}
+	wantScalars := map[string]string{
+		"id":         "123",
+		"enabled":    "TRUE",
+		"price":      "1.0",
+		"created_at": `TIMESTAMP "2023-01-01T00:00:00Z"`,
+	}
 	if diff := cmp.Diff(wantScalars, got); diff != "" {
 		t.Fatalf("(-want +got)\n%s", diff)
 	}

--- a/params/load_test.go
+++ b/params/load_test.go
@@ -54,6 +54,31 @@ func TestLoadParamFile(t *testing.T) {
 	if diff := cmp.Diff(map[string]string{"arr": "ARRAY<STRING>"}, got); diff != "" {
 		t.Fatalf("(-want +got)\n%s", diff)
 	}
+
+	yamlScalarsPath := filepath.Join(dir, "params-scalars.yaml")
+	if err := os.WriteFile(yamlScalarsPath, []byte("id: 123\nenabled: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err = LoadParamFile(yamlScalarsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantScalars := map[string]string{"id": "123", "enabled": "TRUE"}
+	if diff := cmp.Diff(wantScalars, got); diff != "" {
+		t.Fatalf("(-want +got)\n%s", diff)
+	}
+
+	jsonLargeIntPath := filepath.Join(dir, "params-large-int.json")
+	if err := os.WriteFile(jsonLargeIntPath, []byte(`{"id":1234567890123456789}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err = LoadParamFile(jsonLargeIntPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["id"] != "1234567890123456789" {
+		t.Fatalf("got id=%q, want exact integer string", got["id"])
+	}
 }
 
 func TestMergeParams(t *testing.T) {

--- a/params/load_test.go
+++ b/params/load_test.go
@@ -92,6 +92,18 @@ func TestLoadParamFile(t *testing.T) {
 	if _, err := LoadParamFile(nestedPath); err == nil {
 		t.Fatal("expected error for nested array in param file")
 	}
+
+	emptyPath := filepath.Join(dir, "params-empty.yaml")
+	if err := os.WriteFile(emptyPath, []byte("   \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err = LoadParamFile(emptyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty map for empty file, got %v", got)
+	}
 }
 
 func TestMergeParams(t *testing.T) {

--- a/params/load_test.go
+++ b/params/load_test.go
@@ -79,6 +79,14 @@ func TestLoadParamFile(t *testing.T) {
 	if got["id"] != "1234567890123456789" {
 		t.Fatalf("got id=%q, want exact integer string", got["id"])
 	}
+
+	nestedPath := filepath.Join(dir, "params-nested.yaml")
+	if err := os.WriteFile(nestedPath, []byte("arr: [1, 2]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadParamFile(nestedPath); err == nil {
+		t.Fatal("expected error for nested array in param file")
+	}
 }
 
 func TestMergeParams(t *testing.T) {

--- a/params/load_test.go
+++ b/params/load_test.go
@@ -8,23 +8,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestParseParamFlags(t *testing.T) {
-	t.Parallel()
-
-	got, err := ParseParamFlags([]string{"arr:ARRAY<STRING>", "name:42"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := map[string]string{"arr": "ARRAY<STRING>", "name": "42"}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("(-want +got)\n%s", diff)
-	}
-
-	if _, err := ParseParamFlags([]string{"invalid"}); err == nil {
-		t.Fatal("expected error for invalid param")
-	}
-}
-
 func TestLoadParamFile(t *testing.T) {
 	t.Parallel()
 

--- a/params/load_test.go
+++ b/params/load_test.go
@@ -1,0 +1,70 @@
+package params
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseParamFlags(t *testing.T) {
+	t.Parallel()
+
+	got, err := ParseParamFlags([]string{"arr:ARRAY<STRING>", "name:42"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{"arr": "ARRAY<STRING>", "name": "42"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("(-want +got)\n%s", diff)
+	}
+
+	if _, err := ParseParamFlags([]string{"invalid"}); err == nil {
+		t.Fatal("expected error for invalid param")
+	}
+}
+
+func TestLoadParamFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	yamlPath := filepath.Join(dir, "params.yaml")
+	if err := os.WriteFile(yamlPath, []byte("arr: ARRAY<STRING>\nname: \"42\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadParamFile(yamlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{"arr": "ARRAY<STRING>", "name": "42"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("(-want +got)\n%s", diff)
+	}
+
+	jsonPath := filepath.Join(dir, "params.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"arr":"ARRAY<STRING>"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err = LoadParamFile(jsonPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(map[string]string{"arr": "ARRAY<STRING>"}, got); diff != "" {
+		t.Fatalf("(-want +got)\n%s", diff)
+	}
+}
+
+func TestMergeParams(t *testing.T) {
+	t.Parallel()
+
+	got := MergeParams(
+		map[string]string{"a": "1", "b": "2"},
+		map[string]string{"b": "override"},
+	)
+	want := map[string]string{"a": "1", "b": "override"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("(-want +got)\n%s", diff)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `--param-file` to load query parameters from YAML or JSON (`.json` extension selects JSON).
- Merge file params with `--param`; CLI flags override file entries on conflict.

## Test plan
- [x] `go test ./...`


Made with [Cursor](https://cursor.com)