### PR TITLE
Prefer name=value for --param; keep legacy name:value

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Application Options:
       --filter=                                jq filter
   -r, --raw-output                             (--raw-output of jq)
       --filter-file=                           (--from-file of jq)
-      --param=                                 [name]:[Cloud Spanner type(PLAN only) or literal]
+      --param=                                 [name]=[Cloud Spanner type(PLAN only) or literal]; legacy name:value OK
       --param-file=                            YAML or JSON file of query parameters
       --log-grpc                               Show gRPC logs
       --experimental-trace-project=
@@ -79,7 +79,7 @@ There are examples omitting some required options.
 Many Cloud Spanner clients don't support parameter.
 Without modifications, query which have parameters are impossible to execute and query whose parameters' types are `STRUCT` or `ARRAY` are impossible to show query plans.
 
-execspansql supports query parameters via repeated `--param name:value` flags or a `--param-file` (YAML or JSON). When both are given, `--param` overrides entries from the file.
+execspansql supports query parameters via repeated `--param name=value` flags (legacy `name:value` is also accepted) or a `--param-file` (YAML or JSON). When both are given, `--param` overrides entries from the file.
 
 #### PLAN with complex typed parameters
 
@@ -88,12 +88,12 @@ You can use type syntax to plan a query.
 ```
 $ execspansql ${DATABASE_ID} --query-mode=PLAN \
               --sql='SELECT * FROM UNNEST(@arr) WITH OFFSET' \
-              --param='arr:ARRAY<STRUCT<STRING>>'
+              --param='arr=ARRAY<STRUCT<STRING>>'
 ```
 ```
 $ execspansql ${DATABASE_ID} --query-mode=PLAN \
               --sql='SELECT @str.*' \
-              --param='str:STRUCT<FirstName STRING, LastName STRING>'
+              --param='str=STRUCT<FirstName STRING, LastName STRING>'
 ```
 
 #### Parameters from a file
@@ -121,12 +121,12 @@ Note: It only emulates literals and doesn't emulate coercion.
 ```
 $ execspansql ${DATABASE_ID} --query-mode=PROFILE \
               --sql='SELECT * FROM UNNEST(@arr) WITH OFFSET' \
-              --param='arr:[STRUCT<pk INT64, col STRING>(1, "foo"), (42, "foobar")]'
+              --param='arr=[STRUCT<pk INT64, col STRING>(1, "foo"), (42, "foobar")]'
 ```
 ```
 $ execspansql ${DATABASE_ID} --query-mode=PROFILE \
               --sql='SELECT * FROM Singers WHERE STRUCT<FirstName STRING, LastName STRING>(FirstName, LastName) IN UNNEST(@names)' \
-              --param='names:[STRUCT<FirstName STRING, LastName STRING>("John", "Doe"), ("Mary", "Sue")]'
+              --param='names=[STRUCT<FirstName STRING, LastName STRING>("John", "Doe"), ("Mary", "Sue")]'
 ```
 
 ### Embedded jq
@@ -208,7 +208,7 @@ Predicates:
 $ execspansql ${DATABASE_ID} --query-mode=NORMAL \
     --sql='SELECT SingerId FROM SINGERS
            WHERE (FirstName, LastName) = @singerinfo' \
-    --param='singerinfo:STRUCT<FirstName STRING, LastName STRING>("Elena", "Campbell")'
+    --param='singerinfo=STRUCT<FirstName STRING, LastName STRING>("Elena", "Campbell")'
 ```
 
 [Querying data with a STRUCT object](https://cloud.google.com/spanner/docs/structs?hl=en#querying_data_with_an_array_of_struct_objects))
@@ -218,7 +218,7 @@ $ execspansql ${DATABASE_ID} --query-mode=NORMAL \
     --sql='SELECT SingerId FROM SINGERS
            WHERE STRUCT<FirstName STRING, LastName STRING>(FirstName, LastName)
            IN UNNEST(@names)' \
-    --param='names:[STRUCT<FirstName STRING, LastName STRING>("Elena", "Campbell"), ("Hannah", "Harris")]'
+    --param='names=[STRUCT<FirstName STRING, LastName STRING>("Elena", "Campbell"), ("Hannah", "Harris")]'
 ```
 
 
@@ -229,14 +229,14 @@ $ execspansql ${DATABASE_ID} --query-mode=NORMAL \
     --sql='SELECT SingerId
            FROM Singers
            WHERE FirstName = @name.FirstName' \
-    --param='name:STRUCT<FirstName STRING, LastName STRING>("Elena", "Campbell")'
+    --param='name=STRUCT<FirstName STRING, LastName STRING>("Elena", "Campbell")'
 ```
 ```
 $ execspansql ${DATABASE_ID} --query-mode=NORMAL \
     --sql='SELECT SingerId, @songinfo.SongName
            FROM Singers
            WHERE STRUCT<FirstName STRING, LastName STRING>(FirstName, LastName) IN UNNEST(@songinfo.ArtistNames)' \
-     --param='songinfo:STRUCT<SongName STRING, ArtistNames ARRAY<STRUCT<FirstName STRING, LastName STRING>>>("Imagination", [("Elena", "Campbell"), ("Hannah", "Harris")])'
+     --param='songinfo=STRUCT<SongName STRING, ArtistNames ARRAY<STRUCT<FirstName STRING, LastName STRING>>>("Imagination", [("Elena", "Campbell"), ("Hannah", "Harris")])'
 ```
 
 ### (Experimental) Cloud Trace integration

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ type opts struct {
 	JqRawOutput          bool          `name:"raw-output" short:"r" help:"(--raw-output of jq)"`
 	JqFromFile           string        `name:"filter-file" xor:"filter" help:"(--from-file of jq)"`
 	JqInputMode          string        `name:"jq-input-mode" enum:"eager,lazy" default:"eager" help:"How query rows are passed to jq (json/yaml only): eager (full ResultSet), lazy (JQValue root)."`
-	ParamFlags           []string      `name:"param" help:"[name]:[Cloud Spanner type (PLAN only) or literal]"`
+	ParamFlags           []string      `name:"param" help:"[name]=[type or literal]; legacy [name]:[...] also accepted"`
 	ParamFile            string        `name:"param-file" help:"YAML or JSON file of query parameters (name to type/literal string)"`
 	LogGrpc              bool          `name:"log-grpc" help:"Show gRPC logs"`
 	TraceProject         string        `name:"experimental-trace-project" help:"Export traces to Cloud Trace in the given project."`

--- a/params/load.go
+++ b/params/load.go
@@ -14,23 +14,40 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// ParseParamFlags parses repeated --param name:value flags.
+const (
+	paramFlagSeparator       = "="
+	legacyParamFlagSeparator = ":"
+)
+
+// ParseParamFlags parses repeated --param flags as name=value (preferred) or
+// legacy name:value assignments.
 func ParseParamFlags(ss []string) (map[string]string, error) {
 	if len(ss) == 0 {
 		return nil, nil
 	}
 	out := make(map[string]string, len(ss))
 	for _, s := range ss {
-		name, value, err := cliparams.SplitAssignment(s)
+		name, value, err := splitParamFlag(s)
 		if err != nil {
 			return nil, fmt.Errorf("invalid --param %q: %w", s, err)
-		}
-		if name == "" {
-			return nil, fmt.Errorf("invalid --param %q: empty parameter name", s)
 		}
 		out[name] = value
 	}
 	return out, nil
+}
+
+func splitParamFlag(s string) (name, value string, err error) {
+	eqIdx := strings.Index(s, paramFlagSeparator)
+	colonIdx := strings.Index(s, legacyParamFlagSeparator)
+
+	switch {
+	case eqIdx >= 0 && (colonIdx < 0 || eqIdx < colonIdx):
+		return cliparams.SplitAssignment(s, cliparams.WithSeparator(paramFlagSeparator))
+	case colonIdx >= 0:
+		return cliparams.SplitAssignment(s, cliparams.WithSeparator(legacyParamFlagSeparator))
+	default:
+		return "", "", fmt.Errorf("expected name=value or name:value")
+	}
 }
 
 // LoadParamFile loads param name→literal/type strings from a YAML or JSON file.

--- a/params/load_test.go
+++ b/params/load_test.go
@@ -11,7 +11,7 @@ import (
 func TestParseParamFlags(t *testing.T) {
 	t.Parallel()
 
-	got, err := ParseParamFlags([]string{"arr:ARRAY<STRING>", "name:42"})
+	got, err := ParseParamFlags([]string{"arr=ARRAY<STRING>", "name=42"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -22,6 +22,35 @@ func TestParseParamFlags(t *testing.T) {
 
 	if _, err := ParseParamFlags([]string{"invalid"}); err == nil {
 		t.Fatal("expected error for invalid param")
+	}
+
+	if _, err := ParseParamFlags([]string{"=value"}); err == nil {
+		t.Fatal("expected error for empty parameter name")
+	}
+
+	got, err = ParseParamFlags([]string{`expr=a=b`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["expr"] != "a=b" {
+		t.Fatalf("got expr=%q, want %q", got["expr"], "a=b")
+	}
+
+	got, err = ParseParamFlags([]string{"arr:ARRAY<STRING>", "legacy:42"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantLegacy := map[string]string{"arr": "ARRAY<STRING>", "legacy": "42"}
+	if diff := cmp.Diff(wantLegacy, got); diff != "" {
+		t.Fatalf("(-want +got)\n%s", diff)
+	}
+
+	got, err = ParseParamFlags([]string{`key:val=ue`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["key"] != "val=ue" {
+		t.Fatalf("got key=%q, want %q", got["key"], "val=ue")
 	}
 
 	if _, err := ParseParamFlags([]string{":value"}); err == nil {


### PR DESCRIPTION
## Summary
- Prefer `--param name=value` as the documented CLI convention (aligned with Kong and common flag syntax).
- Continue accepting legacy `--param name:value` for backward compatibility.
- When both separators appear, use `=` only if it comes before the first `:` (so `key:val=ue` still parses as legacy).

## Test plan
- [x] `go test ./params/...`
- [ ] Smoke test with `--param arr=ARRAY<STRING>` and `--param arr:ARRAY<STRING>`


Made with [Cursor](https://cursor.com)