### PR TITLE
Tighten CLI logging and jq option validation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
 

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -20,6 +20,8 @@ jobs:
       -
         name: Set up Go
         uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,13 @@
+build:
+	go build -v ./...
+
+lint:
+	golangci-lint run ./...
+
 test:
 	go test -v ./...
+
+update-golden:
+	go test -update-golden ./...
+
+.PHONY: build lint test update-golden

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Yet another `gcloud spanner databases execute-sql` replacement for better compos
   * Query with query parameters
   * Large result sets over 10MB 
 * Embedded jq
-* Emit gRPC message logs
+* Configurable gRPC logging (`off`, `metadata`, `payload` with payload caveat)
 * (Experimental) CSV output
 * (Experimental) Check whether the query can be executed as a partition query or not.
 
@@ -21,41 +21,59 @@ This tool is still pre-release quality and none of guarantees.
 
 You can use [released binaries](https://github.com/apstndb/execspansql/releases).
 ```
-Usage:
-  execspansql [OPTIONS] [database]
+Usage: execspansql --sql=STRING --sql-file=STRING --project=STRING --instance=STRING <database> [flags]
 
-Application Options:
-      --sql=                                   SQL query text; exclusive with --sql-file.
-      --sql-file=                              File name contains SQL query; exclusive with --sql
-  -p, --project=                               (required) ID of the project. [$CLOUDSDK_CORE_PROJECT]
-  -i, --instance=                              (required) ID of the instance. [$CLOUDSDK_SPANNER_INSTANCE]
-      --query-mode=[NORMAL|PLAN|PROFILE]       Query mode. (default: NORMAL)
-      --format=[json|yaml|experimental_csv]    Output format. (default: json)
-      --redact-rows                            Redact result rows from output
-  -c, --compact-output                         Compact JSON output(--compact-output of jq)
-      --filter=                                jq filter
-  -r, --raw-output                             (--raw-output of jq)
-      --filter-file=                           (--from-file of jq)
-      --param=                                 [name]=[Cloud Spanner type(PLAN only) or literal]; legacy name:value OK
-      --param-file=                            YAML or JSON file of query parameters
-      --log-grpc                               Show gRPC logs
-      --experimental-trace-project=                Export traces to Cloud Trace
-      --experimental-trace-stdout                  Export spans to stderr as pretty JSON
-      --experimental-trace-otlp                    Export spans via OTLP/gRPC (local collector)
-      --experimental-trace-otlp-endpoint=          OTLP/gRPC endpoint (default: localhost:4317)
-      --enable-partitioned-dml                 Execute DML statement using Partitioned DML
-      --timeout=                               Maximum time to wait for the SQL query to complete (default: 10m)
-      --try-partition-query                    (Experimental) Check whether the query can be executed as partition query or not
-
-Timestamp Bound:
-      --strong                                 Perform a strong query.
-      --read-timestamp=TIMESTAMP               Perform a query at the given timestamp. (micro-seconds precision)
-
-Help Options:
-  -h, --help                                   Show this help message
+Yet another gcloud spanner databases execute-sql replacement
 
 Arguments:
-  database:                                    (required) ID of the database.
+  <database>    ID of the database.
+
+Flags:
+  -h, --help                       Show context-sensitive help.
+      --sql=STRING                 SQL query text; exclusive with --sql-file.
+      --sql-file=STRING            File name contains SQL query; exclusive with
+                                   --sql
+  -p, --project=STRING             ID of the project ($CLOUDSDK_CORE_PROJECT).
+  -i, --instance=STRING            ID of the instance
+                                   ($CLOUDSDK_SPANNER_INSTANCE).
+      --query-mode="NORMAL"        Query mode.
+      --format="json"              Output format.
+      --redact-rows                Redact result rows from output
+  -c, --compact-output             Compact JSON output (--compact-output of jq)
+      --filter=STRING              jq filter
+  -r, --raw-output                 (--raw-output of jq)
+      --filter-file=STRING         (--from-file of jq)
+      --jq-input-mode="eager"      How query rows are passed to jq (json/yaml
+                                   only): eager (full ResultSet), lazy (JQValue
+                                   root).
+      --param=PARAM,...            [name]=[type or literal]; legacy [name]:[...]
+                                   also accepted
+      --param-file=STRING          YAML or JSON file of query parameters (name
+                                   to type/literal string)
+      --log-grpc="off"             gRPC logging mode: off, metadata, or payload
+                                   (payload may include request and response
+                                   payloads in logs)
+      --experimental-trace-project=STRING
+                                   Export traces to Cloud Trace in the given
+                                   project.
+      --experimental-trace-stdout
+                                   Export spans to stderr as pretty JSON (local
+                                   debugging).
+      --experimental-trace-otlp    Export spans via OTLP/gRPC to a local
+                                   OpenTelemetry collector.
+      --experimental-trace-otlp-endpoint="localhost:4317"
+                                   OTLP/gRPC endpoint used with
+                                   --experimental-trace-otlp.
+      --enable-partitioned-dml     Execute DML statement using Partitioned DML
+      --timeout=10m                Maximum time to wait for the SQL query to
+                                   complete
+      --try-partition-query        (Experimental) Check whether the query can be
+                                   executed as partition query or not
+
+Timestamp Bound
+  --strong                   Perform a strong query.
+  --read-timestamp=STRING    Perform a query at the given timestamp.
+                             (micro-seconds precision)
 ```
 
 Local build requires Go 1.25.
@@ -70,7 +88,7 @@ $ docker run --rm -t -v "${HOME}/.config/gcloud/application_default_credentials.
     ghcr.io/apstndb/execspansql/execspansql:latest -p ${SPANNER_PROJECT} -i ${SPANNER_INSTANCE} ${SPANNER_DATABASE} --sql 'SELECT 1'
 # or use specific version
 $ docker run --rm -t -v "${HOME}/.config/gcloud/application_default_credentials.json:/home/nonroot/.config/gcloud/application_default_credentials.json:ro" \
-    ghcr.io/apstndb/execspansql/execspansql:v0.3.3 -p ${SPANNER_PROJECT} -i ${SPANNER_INSTANCE} ${SPANNER_DATABASE} --sql 'SELECT 1'
+    ghcr.io/apstndb/execspansql/execspansql:vX.Y.Z -p ${SPANNER_PROJECT} -i ${SPANNER_INSTANCE} ${SPANNER_DATABASE} --sql 'SELECT 1'
 ```
 
 ## Notable features
@@ -144,6 +162,8 @@ execspansql can process output using embedded [wader/gojq](https://github.com/wa
 | `lazy` | `JQValue` root (`metadata` / `rows` Iter / `stats`) | `.rows[]`, `.stats.queryPlan` |
 
 In `lazy` mode, `metadata` is populated after the first row is read from Spanner (or after a zero-row result). Prefer `.rows[]` to stream rows. Bare `.rows` is a lazy iterator: reuse it in one object literal (for example `{a: .rows, b: .rows}`) may not duplicate rows because jq can evaluate the subexpression once; use `{a: [.rows[]], b: [.rows[]]}` when you need two row arrays. After `.stats` drains the iterator, captured `.rows` values replay from materialized rows.
+
+`--jq-input-mode=lazy` emits rows incrementally, but rows are cached internally after first materialization and reused, so it is not a strict constant-memory mode for large result sets.
 
 Output expands top-level `gojq.Iter` to one JSON/YAML document per row (JSONL-style). Nested `Iter` values inside objects are expanded to arrays on encode.
 
@@ -279,12 +299,17 @@ $ execspansql $DATABASE_ID --query-mode=PROFILE --sql 'SELECT 1' --experimental-
 ```
 
 Note: `--experimental-trace-stdout` writes to **stderr**, not stdout.
+Note: `--log-grpc=payload` can log request and response payloads (including bound parameters and row values) and should only be used in trusted environments.
 
 ![trace.png](docs/trace.png)
 
 ### (Experimental) `--try-partition-query`
 
 Check whether the query can be executed as partition query or not.
+
+By default this checks against the current schema using a strong read. Pass `--read-timestamp` to check partitionability against a historical schema within the database version retention window.
+
+`--try-partition-query` is a query-routing check and rejects jq-related options (`--filter`, `--filter-file`, `--raw-output`, `--compact-output`) and `--jq-input-mode=lazy`.
 
 ```
 $ execspansql ${DATABASE_ID} --sql='SELECT * FROM Singers JOIN Albums USING(SingerId)' --try-partition-query
@@ -298,4 +323,5 @@ exit status 1
 
 ## Limitations
 
-* Supports only json and yaml format
+* `--format=experimental_csv` does not run the jq pipeline; `--filter`, `--filter-file`, `--raw-output`, `--compact-output`, and `--jq-input-mode=lazy` are rejected.
+* `--raw-output` and `--compact-output` are supported only when `--format=json`.

--- a/flags_validation_test.go
+++ b/flags_validation_test.go
@@ -189,6 +189,12 @@ func TestBuildGrpcZapLoggerFallback(t *testing.T) {
 	}
 }
 
+func optsWithReadTimestamp(ts string) opts {
+	var o opts
+	o.TimestampBound.ReadTimestamp = ts
+	return o
+}
+
 func TestValidateExecutionOptions(t *testing.T) {
 	t.Parallel()
 
@@ -219,30 +225,22 @@ func TestValidateExecutionOptions(t *testing.T) {
 		},
 		{
 			name: "read_timestamp_allows_single_query",
-			o: opts{TimestampBound: struct {
-				Strong        bool   `name:"strong" xor:"timestamp" help:"Perform a strong query."`
-				ReadTimestamp string `name:"read-timestamp" xor:"timestamp" help:"Perform a query at the given timestamp. (micro-seconds precision)"`
-			}{ReadTimestamp: "2025-01-01T00:00:00Z"}},
+			o:    optsWithReadTimestamp("2025-01-01T00:00:00Z"),
 			mode: single{queryTimestamp},
 		},
 		{
 			name: "read_timestamp_rejects_dml",
-			o: opts{TimestampBound: struct {
-				Strong        bool   `name:"strong" xor:"timestamp" help:"Perform a strong query."`
-				ReadTimestamp string `name:"read-timestamp" xor:"timestamp" help:"Perform a query at the given timestamp. (micro-seconds precision)"`
-			}{ReadTimestamp: "2025-01-01T00:00:00Z"}},
+			o:    optsWithReadTimestamp("2025-01-01T00:00:00Z"),
 			mode: readWrite{},
 			err:  "--read-timestamp cannot be used with DML statements",
 		},
 		{
 			name: "read_timestamp_rejects_partitioned_dml",
-			o: opts{
-				EnablePartitionedDML: true,
-				TimestampBound: struct {
-					Strong        bool   `name:"strong" xor:"timestamp" help:"Perform a strong query."`
-					ReadTimestamp string `name:"read-timestamp" xor:"timestamp" help:"Perform a query at the given timestamp. (micro-seconds precision)"`
-				}{ReadTimestamp: "2025-01-01T00:00:00Z"},
-			},
+			o: func() opts {
+				o := optsWithReadTimestamp("2025-01-01T00:00:00Z")
+				o.EnablePartitionedDML = true
+				return o
+			}(),
 			mode: partitionedDML{},
 			err:  "--read-timestamp cannot be combined with --enable-partitioned-dml",
 		},

--- a/flags_validation_test.go
+++ b/flags_validation_test.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/execspansql/jqresult"
+)
+
+func TestValidateJqOutputOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		o    opts
+		mode jqresult.InputMode
+		err  string
+	}{
+		{name: "json_defaults", o: opts{}, mode: jqresult.InputEager},
+		{name: "json_raw_with_json", o: opts{Format: "json", JqRawOutput: true}, mode: jqresult.InputEager},
+		{
+			name: "yaml_raw_output_not_allowed",
+			o:    opts{Format: "yaml", JqRawOutput: true},
+			mode: jqresult.InputEager,
+			err:  "--raw-output and --compact-output are only supported with --format=json",
+		},
+		{
+			name: "yaml_compact_output_not_allowed",
+			o:    opts{Format: "yaml", CompactOutput: true},
+			mode: jqresult.InputEager,
+			err:  "--raw-output and --compact-output are only supported with --format=json",
+		},
+		{
+			name: "experimental_csv_filter_not_allowed",
+			o:    opts{Format: "experimental_csv", JqFilter: "."},
+			mode: jqresult.InputEager,
+			err:  "--format=experimental_csv does not support jq filtering options",
+		},
+		{
+			name: "experimental_csv_lazy_not_allowed",
+			o:    opts{Format: "experimental_csv", JqInputMode: "lazy"},
+			mode: jqresult.InputLazy,
+			err:  "--format=experimental_csv does not support jq filtering options",
+		},
+		{
+			name: "try_partition_filter_not_allowed",
+			o:    opts{TryPartitionQuery: true, JqFilter: "."},
+			mode: jqresult.InputEager,
+			err:  "--try-partition-query does not support jq filtering options",
+		},
+		{
+			name: "try_partition_jq_output_mode_lazy_not_allowed",
+			o:    opts{TryPartitionQuery: true, JqInputMode: "lazy"},
+			mode: jqresult.InputLazy,
+			err:  "--try-partition-query does not support jq filtering options",
+		},
+		{
+			name: "try_partition_compact_output_not_allowed",
+			o:    opts{Format: "yaml", TryPartitionQuery: true, CompactOutput: true},
+			mode: jqresult.InputEager,
+			err:  "--raw-output and --compact-output are only supported with --format=json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateJqOutputOptions(tt.o, tt.mode)
+			if tt.err == "" {
+				if err != nil {
+					t.Fatalf("validateJqOutputOptions() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateJqOutputOptions() expected error containing %q", tt.err)
+			}
+			if !strings.Contains(err.Error(), tt.err) {
+				t.Fatalf("validateJqOutputOptions() error = %q, want %q", err, tt.err)
+			}
+		})
+	}
+}
+
+func TestIsReadWriteStatement(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		query   string
+		wantDML bool
+	}{
+		{name: "plain_update", query: "UPDATE T SET X=1", wantDML: true},
+		{name: "commented_update", query: "/* comment */ UPDATE T SET X=1", wantDML: true},
+		{name: "line_comment_update", query: "-- comment\nUPDATE T SET X=1", wantDML: true},
+		{name: "hash_comment_update", query: "# comment\nINSERT T(a) VALUES(1)", wantDML: true},
+		{name: "plain_select", query: "SELECT 1", wantDML: false},
+		{name: "commented_select", query: "-- comment\nSELECT 1", wantDML: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isReadWriteStatement(tt.query); got != tt.wantDML {
+				t.Fatalf("isReadWriteStatement(%q) = %v, want %v", tt.query, got, tt.wantDML)
+			}
+		})
+	}
+}
+
+func TestParseTimestampBound(t *testing.T) {
+	t.Parallel()
+
+	timestamp := time.Date(2026, 7, 4, 12, 34, 56, 0, time.UTC)
+	tests := []struct {
+		name string
+		raw  string
+		want string
+		err  bool
+	}{
+		{
+			name: "default_to_strong",
+			raw:  "",
+			want: spanner.StrongRead().String(),
+		},
+		{
+			name: "read_timestamp",
+			raw:  timestamp.Format(time.RFC3339Nano),
+			want: spanner.ReadTimestamp(timestamp).String(),
+		},
+		{
+			name: "invalid_timestamp",
+			raw:  "bad",
+			err:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTimestampBound(tt.raw)
+			if tt.err {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTimestampBound(%q) error = %v", tt.raw, err)
+			}
+			if got.String() != tt.want {
+				t.Fatalf("parseTimestampBound(%q) = %q, want %q", tt.raw, got.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestLogGrpcClientOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode string
+		want int
+	}{
+		{name: "off", mode: logGrpcModeOff, want: 0},
+		{name: "metadata", mode: logGrpcModeMetadata, want: 2},
+		{name: "payload", mode: logGrpcModePayload, want: 2},
+		{name: "unknown", mode: "unexpected", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := len(logGrpcClientOptions(tt.mode)); got != tt.want {
+				t.Fatalf("len(logGrpcClientOptions(%q)) = %d, want %d", tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQueryModeForQuery(t *testing.T) {
+	t.Parallel()
+
+	tb := spanner.StrongRead()
+	candidateTimestamp := spanner.ReadTimestamp(time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC))
+
+	tests := []struct {
+		name               string
+		query              string
+		partitionedEnabled bool
+		tb                 spanner.TimestampBound
+		wantMode           string
+	}{
+		{name: "dml_with_comment", query: "-- c\nUPDATE T SET X=1", partitionedEnabled: false, tb: tb, wantMode: "readWrite"},
+		{name: "partitioned_dml", query: "UPDATE T SET X=1", partitionedEnabled: true, tb: tb, wantMode: "partitionedDML"},
+		{name: "normal_query", query: "SELECT 1", partitionedEnabled: false, tb: candidateTimestamp, wantMode: "single"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := queryModeForQuery(tt.query, tt.partitionedEnabled, tt.tb)
+			switch tt.wantMode {
+			case "readWrite":
+				if _, ok := got.(readWrite); !ok {
+					t.Fatalf("queryModeForQuery() = %T, want readWrite", got)
+				}
+			case "partitionedDML":
+				if _, ok := got.(partitionedDML); !ok {
+					t.Fatalf("queryModeForQuery() = %T, want partitionedDML", got)
+				}
+			case "single":
+				s, ok := got.(single)
+				if !ok {
+					t.Fatalf("queryModeForQuery() = %T, want single", got)
+				}
+				if s.String() != tt.tb.String() {
+					t.Fatalf("queryModeForQuery() tb = %q, want %q", s.String(), tt.tb.String())
+				}
+			}
+		})
+	}
+}

--- a/flags_validation_test.go
+++ b/flags_validation_test.go
@@ -7,6 +7,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"github.com/apstndb/execspansql/jqresult"
+	"go.uber.org/zap"
 )
 
 func TestValidateJqOutputOptions(t *testing.T) {
@@ -172,6 +173,95 @@ func TestLogGrpcClientOptions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := len(logGrpcClientOptions(tt.mode)); got != tt.want {
 				t.Fatalf("len(logGrpcClientOptions(%q)) = %d, want %d", tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildGrpcZapLoggerFallback(t *testing.T) {
+	t.Parallel()
+
+	cfg := zap.NewDevelopmentConfig()
+	cfg.OutputPaths = []string{"unknown-sink://stderr"}
+
+	if got := buildGrpcZapLogger(cfg); got == nil {
+		t.Fatal("buildGrpcZapLogger() returned nil")
+	}
+}
+
+func TestValidateExecutionOptions(t *testing.T) {
+	t.Parallel()
+
+	queryTimestamp := spanner.ReadTimestamp(time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC))
+
+	tests := []struct {
+		name string
+		o    opts
+		mode queryMode
+		err  string
+	}{
+		{
+			name: "try_partition_allows_single_query",
+			o:    opts{TryPartitionQuery: true},
+			mode: single{spanner.StrongRead()},
+		},
+		{
+			name: "try_partition_rejects_dml",
+			o:    opts{TryPartitionQuery: true},
+			mode: readWrite{},
+			err:  "--try-partition-query cannot be used with DML statements",
+		},
+		{
+			name: "try_partition_rejects_partitioned_dml",
+			o:    opts{TryPartitionQuery: true, EnablePartitionedDML: true},
+			mode: partitionedDML{},
+			err:  "--try-partition-query cannot be combined with --enable-partitioned-dml",
+		},
+		{
+			name: "read_timestamp_allows_single_query",
+			o: opts{TimestampBound: struct {
+				Strong        bool   `name:"strong" xor:"timestamp" help:"Perform a strong query."`
+				ReadTimestamp string `name:"read-timestamp" xor:"timestamp" help:"Perform a query at the given timestamp. (micro-seconds precision)"`
+			}{ReadTimestamp: "2025-01-01T00:00:00Z"}},
+			mode: single{queryTimestamp},
+		},
+		{
+			name: "read_timestamp_rejects_dml",
+			o: opts{TimestampBound: struct {
+				Strong        bool   `name:"strong" xor:"timestamp" help:"Perform a strong query."`
+				ReadTimestamp string `name:"read-timestamp" xor:"timestamp" help:"Perform a query at the given timestamp. (micro-seconds precision)"`
+			}{ReadTimestamp: "2025-01-01T00:00:00Z"}},
+			mode: readWrite{},
+			err:  "--read-timestamp cannot be used with DML statements",
+		},
+		{
+			name: "read_timestamp_rejects_partitioned_dml",
+			o: opts{
+				EnablePartitionedDML: true,
+				TimestampBound: struct {
+					Strong        bool   `name:"strong" xor:"timestamp" help:"Perform a strong query."`
+					ReadTimestamp string `name:"read-timestamp" xor:"timestamp" help:"Perform a query at the given timestamp. (micro-seconds precision)"`
+				}{ReadTimestamp: "2025-01-01T00:00:00Z"},
+			},
+			mode: partitionedDML{},
+			err:  "--read-timestamp cannot be combined with --enable-partitioned-dml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateExecutionOptions(tt.o, tt.mode)
+			if tt.err == "" {
+				if err != nil {
+					t.Fatalf("validateExecutionOptions() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateExecutionOptions() expected error containing %q", tt.err)
+			}
+			if !strings.Contains(err.Error(), tt.err) {
+				t.Fatalf("validateExecutionOptions() error = %q, want %q", err, tt.err)
 			}
 		})
 	}

--- a/flags_validation_test.go
+++ b/flags_validation_test.go
@@ -61,7 +61,7 @@ func TestValidateJqOutputOptions(t *testing.T) {
 			name: "try_partition_compact_output_not_allowed",
 			o:    opts{Format: "yaml", TryPartitionQuery: true, CompactOutput: true},
 			mode: jqresult.InputEager,
-			err:  "--raw-output and --compact-output are only supported with --format=json",
+			err:  "--try-partition-query does not support jq filtering options",
 		},
 	}
 
@@ -195,6 +195,12 @@ func optsWithReadTimestamp(ts string) opts {
 	return o
 }
 
+func optsWithStrong() opts {
+	var o opts
+	o.TimestampBound.Strong = true
+	return o
+}
+
 func TestValidateExecutionOptions(t *testing.T) {
 	t.Parallel()
 
@@ -243,6 +249,22 @@ func TestValidateExecutionOptions(t *testing.T) {
 			}(),
 			mode: partitionedDML{},
 			err:  "--read-timestamp cannot be combined with --enable-partitioned-dml",
+		},
+		{
+			name: "strong_rejects_dml",
+			o:    optsWithStrong(),
+			mode: readWrite{},
+			err:  "--strong cannot be used with DML statements",
+		},
+		{
+			name: "strong_rejects_partitioned_dml",
+			o: func() opts {
+				o := optsWithStrong()
+				o.EnablePartitionedDML = true
+				return o
+			}(),
+			mode: partitionedDML{},
+			err:  "--strong cannot be combined with --enable-partitioned-dml",
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/apstndb/execspansql/params"
 	"io"
+	"strings"
 	"time"
 
 	"fmt"
@@ -26,12 +26,19 @@ import (
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/alecthomas/kong"
 	"github.com/apstndb/execspansql/jqresult"
+	"github.com/apstndb/execspansql/params"
 	"github.com/apstndb/execspansql/resultset"
 	"github.com/apstndb/gsqlutils/stmtkind"
 	"github.com/apstndb/spaniter"
 	"github.com/apstndb/spannerotel/interceptor"
 	svwriter "github.com/apstndb/spanvalue/writer"
 	"github.com/wader/gojq"
+)
+
+const (
+	logGrpcModeOff      = "off"
+	logGrpcModeMetadata = "metadata"
+	logGrpcModePayload  = "payload"
 )
 
 func main() {
@@ -68,7 +75,7 @@ type opts struct {
 	JqInputMode          string        `name:"jq-input-mode" enum:"eager,lazy" default:"eager" help:"How query rows are passed to jq (json/yaml only): eager (full ResultSet), lazy (JQValue root)."`
 	ParamFlags           []string      `name:"param" help:"[name]=[type or literal]; legacy [name]:[...] also accepted"`
 	ParamFile            string        `name:"param-file" help:"YAML or JSON file of query parameters (name to type/literal string)"`
-	LogGrpc              bool          `name:"log-grpc" help:"Show gRPC logs"`
+	LogGrpc              string        `name:"log-grpc" enum:"off,metadata,payload" default:"off" help:"gRPC logging mode: off, metadata, or payload (payload may include request and response payloads in logs)"`
 	TraceProject         string        `name:"experimental-trace-project" xor:"trace" help:"Export traces to Cloud Trace in the given project."`
 	TraceStdout          bool          `name:"experimental-trace-stdout" xor:"trace" help:"Export spans to stderr as pretty JSON (local debugging)."`
 	TraceOTLP            bool          `name:"experimental-trace-otlp" xor:"trace" help:"Export spans via OTLP/gRPC to a local OpenTelemetry collector."`
@@ -127,16 +134,6 @@ func processFlags() (o opts, err error) {
 		}
 		return o, err
 	}
-
-	if o.TimestampBound.ReadTimestamp != "" {
-		if _, err := time.Parse(time.RFC3339Nano, o.TimestampBound.ReadTimestamp); err != nil {
-			return o, fmt.Errorf("--read-timestamp is supplied but wrong: %w", err)
-		}
-	}
-
-	if _, err := jqresult.ParseInputMode(o.JqInputMode); err != nil {
-		return o, err
-	}
 	return o, nil
 }
 
@@ -152,24 +149,115 @@ func readFileOrDefault(filename, s string) (string, error) {
 	return string(b), nil
 }
 
-func logGrpcClientOptions() []option.ClientOption {
+func parseTimestampBound(rawReadTimestamp string) (spanner.TimestampBound, error) {
+	if rawReadTimestamp == "" {
+		return spanner.StrongRead(), nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, rawReadTimestamp)
+	if err != nil {
+		return spanner.TimestampBound{}, err
+	}
+	return spanner.ReadTimestamp(parsed), nil
+}
+
+func stripLeadingComments(query string) string {
+	for {
+		query = strings.TrimLeft(query, " \t\r\n")
+		if query == "" {
+			return ""
+		}
+
+		switch {
+		case strings.HasPrefix(query, "--"):
+			if i := strings.IndexAny(query[2:], "\r\n"); i >= 0 {
+				query = query[2+i+1:]
+				continue
+			}
+			return ""
+		case strings.HasPrefix(query, "#"):
+			if i := strings.IndexAny(query[1:], "\r\n"); i >= 0 {
+				query = query[1+i+1:]
+				continue
+			}
+			return ""
+		case strings.HasPrefix(query, "/*"):
+			if i := strings.Index(query[2:], "*/"); i >= 0 {
+				query = query[i+4:]
+				continue
+			}
+			return ""
+		default:
+			return query
+		}
+	}
+}
+
+func isReadWriteStatement(query string) bool {
+	return stmtkind.IsDMLLexical(stripLeadingComments(query))
+}
+
+func queryModeForQuery(query string, enablePartitionedDML bool, tb spanner.TimestampBound) queryMode {
+	if enablePartitionedDML {
+		return partitionedDML{}
+	}
+	if isReadWriteStatement(query) {
+		return readWrite{}
+	}
+	return single{tb}
+}
+
+func validateJqOutputOptions(o opts, mode jqresult.InputMode) error {
+	if o.Format != "json" && (o.JqRawOutput || o.CompactOutput) {
+		return fmt.Errorf("--raw-output and --compact-output are only supported with --format=json")
+	}
+
+	if o.Format == "experimental_csv" {
+		if o.JqFilter != "" || o.JqFromFile != "" || o.JqRawOutput || o.CompactOutput || mode == jqresult.InputLazy {
+			return fmt.Errorf("--format=experimental_csv does not support jq filtering options")
+		}
+		return nil
+	}
+
+	if o.TryPartitionQuery {
+		if o.JqFilter != "" || o.JqFromFile != "" || o.JqRawOutput || o.CompactOutput || mode == jqresult.InputLazy {
+			return fmt.Errorf("--try-partition-query does not support jq filtering options")
+		}
+	}
+	return nil
+}
+
+func logGrpcClientOptions(logGrpcMode string) []option.ClientOption {
 	zapDevelopmentConfig := zap.NewDevelopmentConfig()
 	zapDevelopmentConfig.DisableCaller = true
 	zapLogger, _ := zapDevelopmentConfig.Build(zap.Fields())
 
-	return []option.ClientOption{
-		option.WithGRPCDialOption(grpc.WithChainUnaryInterceptor(
-			grpczap.PayloadUnaryClientInterceptor(zapLogger, func(ctx context.Context, fullMethodName string) bool {
-				return true
-			}),
-			grpczap.UnaryClientInterceptor(zapLogger),
-		)),
-		option.WithGRPCDialOption(grpc.WithChainStreamInterceptor(
-			grpczap.PayloadStreamClientInterceptor(zapLogger, func(ctx context.Context, fullMethodName string) bool {
-				return true
-			}),
-			grpczap.StreamClientInterceptor(zapLogger),
-		)),
+	switch logGrpcMode {
+	case logGrpcModeMetadata:
+		return []option.ClientOption{
+			option.WithGRPCDialOption(grpc.WithChainUnaryInterceptor(
+				grpczap.UnaryClientInterceptor(zapLogger),
+			)),
+			option.WithGRPCDialOption(grpc.WithChainStreamInterceptor(
+				grpczap.StreamClientInterceptor(zapLogger),
+			)),
+		}
+	case logGrpcModePayload:
+		return []option.ClientOption{
+			option.WithGRPCDialOption(grpc.WithChainUnaryInterceptor(
+				grpczap.PayloadUnaryClientInterceptor(zapLogger, func(ctx context.Context, fullMethodName string) bool {
+					return true
+				}),
+				grpczap.UnaryClientInterceptor(zapLogger),
+			)),
+			option.WithGRPCDialOption(grpc.WithChainStreamInterceptor(
+				grpczap.PayloadStreamClientInterceptor(zapLogger, func(ctx context.Context, fullMethodName string) bool {
+					return true
+				}),
+				grpczap.StreamClientInterceptor(zapLogger),
+			)),
+		}
+	default:
+		return nil
 	}
 }
 
@@ -245,18 +333,26 @@ func _main() error {
 	if err := jqMode.ValidateFormat(o.Format); err != nil {
 		return err
 	}
-
-	jqFilter, err := readFileOrDefault(o.JqFromFile, o.JqFilter)
-	if err != nil {
+	if err := validateJqOutputOptions(o, jqMode); err != nil {
 		return err
 	}
-	if jqFilter == "" {
-		jqFilter = jqresult.DefaultFilter(jqMode)
-	}
 
-	jqCode, err := jqresult.Compile(jqFilter, jqMode)
-	if err != nil {
-		return err
+	var (
+		jqCode *gojq.Code
+	)
+	if !o.TryPartitionQuery && o.Format != "experimental_csv" {
+		jqFilter, err := readFileOrDefault(o.JqFromFile, o.JqFilter)
+		if err != nil {
+			return err
+		}
+		if jqFilter == "" {
+			jqFilter = jqresult.DefaultFilter(jqMode)
+		}
+
+		jqCode, err = jqresult.Compile(jqFilter, jqMode)
+		if err != nil {
+			return err
+		}
 	}
 
 	mode := sppb.ExecuteSqlRequest_QueryMode(sppb.ExecuteSqlRequest_QueryMode_value[o.QueryMode])
@@ -264,6 +360,11 @@ func _main() error {
 	query, err := readFileOrDefault(o.SqlFile, o.Sql)
 	if err != nil {
 		return err
+	}
+
+	tb, err := parseTimestampBound(o.TimestampBound.ReadTimestamp)
+	if err != nil {
+		return fmt.Errorf("--read-timestamp is supplied but wrong: %w", err)
 	}
 
 	ctx, tp, traceCancel, err := enableTracing(ctx, o)
@@ -281,9 +382,7 @@ func _main() error {
 		}()
 	}
 
-	logGrpc := o.LogGrpc
-
-	client, err := newClient(ctx, o.Project, o.Instance, o.Database, logGrpc, tracingEnabled(o))
+	client, err := newClient(ctx, o.Project, o.Instance, o.Database, o.LogGrpc, tracingEnabled(o))
 	if err != nil {
 		return err
 	}
@@ -298,26 +397,7 @@ func _main() error {
 		return err
 	}
 
-	var tb spanner.TimestampBound
-	if o.TimestampBound.ReadTimestamp != "" {
-		ts, err := time.Parse(time.RFC3339Nano, o.TimestampBound.ReadTimestamp)
-		if err != nil {
-			return err
-		}
-		tb = spanner.ReadTimestamp(ts)
-	} else {
-		tb = spanner.StrongRead()
-	}
-
-	var m queryMode
-	switch {
-	case o.EnablePartitionedDML:
-		m = partitionedDML{}
-	case stmtkind.IsDMLLexical(query):
-		m = readWrite{}
-	default:
-		m = single{tb}
-	}
+	m := queryModeForQuery(query, o.EnablePartitionedDML, tb)
 
 	stmt := spanner.Statement{SQL: query, Params: paramMap}
 
@@ -433,12 +513,12 @@ func writeCsvFromResultSet(writer io.Writer, rs *sppb.ResultSet) error {
 	return csvWriter.Flush()
 }
 
-func newClient(ctx context.Context, project, instance, database string, logGrpc bool, doTrace bool) (*spanner.Client, error) {
+func newClient(ctx context.Context, project, instance, database string, logGrpcMode string, doTrace bool) (*spanner.Client, error) {
 	name := fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, instance, database)
 
 	var copts []option.ClientOption
-	if logGrpc {
-		copts = logGrpcClientOptions()
+	if logGrpcMode != logGrpcModeOff {
+		copts = logGrpcClientOptions(logGrpcMode)
 	}
 
 	if doTrace {

--- a/main.go
+++ b/main.go
@@ -247,7 +247,7 @@ func validateJqOutputOptions(o opts, mode jqresult.InputMode) error {
 }
 
 func buildGrpcZapLogger(config zap.Config) *zap.Logger {
-	zapLogger, err := config.Build(zap.Fields())
+	zapLogger, err := config.Build()
 	if err != nil {
 		return zap.NewNop()
 	}

--- a/main.go
+++ b/main.go
@@ -215,22 +215,22 @@ func validateExecutionOptions(o opts, mode queryMode) error {
 			return fmt.Errorf("--try-partition-query cannot be used with DML statements")
 		}
 	}
-	if o.TimestampBound.ReadTimestamp != "" {
+	if o.TimestampBound.ReadTimestamp != "" || o.TimestampBound.Strong {
 		if _, ok := mode.(single); !ok {
-			if o.EnablePartitionedDML {
-				return fmt.Errorf("--read-timestamp cannot be combined with --enable-partitioned-dml")
+			flagName := "--read-timestamp"
+			if o.TimestampBound.Strong {
+				flagName = "--strong"
 			}
-			return fmt.Errorf("--read-timestamp cannot be used with DML statements")
+			if o.EnablePartitionedDML {
+				return fmt.Errorf("%s cannot be combined with --enable-partitioned-dml", flagName)
+			}
+			return fmt.Errorf("%s cannot be used with DML statements", flagName)
 		}
 	}
 	return nil
 }
 
 func validateJqOutputOptions(o opts, mode jqresult.InputMode) error {
-	if o.Format != "json" && (o.JqRawOutput || o.CompactOutput) {
-		return fmt.Errorf("--raw-output and --compact-output are only supported with --format=json")
-	}
-
 	if o.Format == "experimental_csv" {
 		if o.JqFilter != "" || o.JqFromFile != "" || o.JqRawOutput || o.CompactOutput || mode == jqresult.InputLazy {
 			return fmt.Errorf("--format=experimental_csv does not support jq filtering options")
@@ -242,6 +242,9 @@ func validateJqOutputOptions(o opts, mode jqresult.InputMode) error {
 		if o.JqFilter != "" || o.JqFromFile != "" || o.JqRawOutput || o.CompactOutput || mode == jqresult.InputLazy {
 			return fmt.Errorf("--try-partition-query does not support jq filtering options")
 		}
+	}
+	if o.Format != "json" && (o.JqRawOutput || o.CompactOutput) {
+		return fmt.Errorf("--raw-output and --compact-output are only supported with --format=json")
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -206,6 +206,26 @@ func queryModeForQuery(query string, enablePartitionedDML bool, tb spanner.Times
 	return single{tb}
 }
 
+func validateExecutionOptions(o opts, mode queryMode) error {
+	if o.TryPartitionQuery {
+		if _, ok := mode.(single); !ok {
+			if o.EnablePartitionedDML {
+				return fmt.Errorf("--try-partition-query cannot be combined with --enable-partitioned-dml")
+			}
+			return fmt.Errorf("--try-partition-query cannot be used with DML statements")
+		}
+	}
+	if o.TimestampBound.ReadTimestamp != "" {
+		if _, ok := mode.(single); !ok {
+			if o.EnablePartitionedDML {
+				return fmt.Errorf("--read-timestamp cannot be combined with --enable-partitioned-dml")
+			}
+			return fmt.Errorf("--read-timestamp cannot be used with DML statements")
+		}
+	}
+	return nil
+}
+
 func validateJqOutputOptions(o opts, mode jqresult.InputMode) error {
 	if o.Format != "json" && (o.JqRawOutput || o.CompactOutput) {
 		return fmt.Errorf("--raw-output and --compact-output are only supported with --format=json")
@@ -226,10 +246,18 @@ func validateJqOutputOptions(o opts, mode jqresult.InputMode) error {
 	return nil
 }
 
+func buildGrpcZapLogger(config zap.Config) *zap.Logger {
+	zapLogger, err := config.Build(zap.Fields())
+	if err != nil {
+		return zap.NewNop()
+	}
+	return zapLogger
+}
+
 func logGrpcClientOptions(logGrpcMode string) []option.ClientOption {
 	zapDevelopmentConfig := zap.NewDevelopmentConfig()
 	zapDevelopmentConfig.DisableCaller = true
-	zapLogger, _ := zapDevelopmentConfig.Build(zap.Fields())
+	zapLogger := buildGrpcZapLogger(zapDevelopmentConfig)
 
 	switch logGrpcMode {
 	case logGrpcModeMetadata:
@@ -367,6 +395,11 @@ func _main() error {
 		return fmt.Errorf("--read-timestamp is supplied but wrong: %w", err)
 	}
 
+	m := queryModeForQuery(query, o.EnablePartitionedDML, tb)
+	if err := validateExecutionOptions(o, m); err != nil {
+		return err
+	}
+
 	ctx, tp, traceCancel, err := enableTracing(ctx, o)
 	if err != nil {
 		return err
@@ -396,8 +429,6 @@ func _main() error {
 	if err != nil {
 		return err
 	}
-
-	m := queryModeForQuery(query, o.EnablePartitionedDML, tb)
 
 	stmt := spanner.Statement{SQL: query, Params: paramMap}
 


### PR DESCRIPTION
## Summary

- Change `--log-grpc` to an explicit `off|metadata|payload` mode so payload logging requires an intentional opt-in.
- Reject jq/raw/compact options on output paths that do not use them, and avoid compiling jq filters for CSV and partition-query checks.
- Add focused routing and validation tests for comment-prefixed DML, timestamp bounds, gRPC logging modes, and unsupported flag combinations.
- Refresh README help text, jq lazy-mode memory wording, partition-query timestamp guidance, gRPC payload caveats, Makefile targets, and Go workflow setup.

Closes #58.
Closes #59.
Closes #60.
Closes #61.
Closes #62.
Closes #63.

## Validation

- `git diff --check`
- `go test ./params/... ./jqresult/... ./resultset/...`
- `go test .`
- `make build`
- `make lint`
- `make test`
