### PR TITLE
Align GoReleaser config with v2 schema and actual release needs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,19 +1,12 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
-# Make sure to check the documentation at https://goreleaser.com
-
-# The lines below are called `modelines`. See `:help modeline`
-# Feel free to remove those if you don't want/need to use them.
+# GoReleaser v2 config for execspansql cross-platform CLI releases.
+# Triggered by .github/workflows/goreleaser.yml on tag push (goreleaser-action@v6).
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-# vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
 version: 2
 
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod tidy
-    # you may remove this if you don't need go generate
-    - go generate ./...
 
 builds:
   - env:
@@ -24,8 +17,8 @@ builds:
       - darwin
 
 archives:
-  - format: tar.gz
-    # this name template makes the OS and Arch compatible with the results of `uname`.
+  - formats:
+      - tar.gz
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
@@ -33,10 +26,10 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
 changelog:
   sort: asc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ For fast local checks without Docker dependency, limit to package-level tests as
 
 - CI workflows include lint and Go build/test under `.github/workflows/`.
 - Lint workflow uses `golangci-lint`.
-- `ko` publish workflow builds on tag pushes for `v*`.
-- `.goreleaser.yaml` exists and should be treated as release automation metadata.
+- `ko` publish workflow builds container images on tag pushes for `v*`.
+- GoReleaser (`.goreleaser.yaml`, v2 schema) publishes cross-platform CLI archives via `.github/workflows/goreleaser.yml` on any tag push; `before.hooks` runs `go mod tidy` only (no `go:generate` in this repo).
 - Release/packaging behavior follows `go.mod` Go version pin (`go 1.25.0`).
 
 ## Repository hygiene


### PR DESCRIPTION
## Summary

- Remove stock GoReleaser example boilerplate and the unused `go generate ./...` before hook (no `//go:generate` in the repo).
- Migrate deprecated archive `format` keys to GoReleaser v2 `formats` list syntax so `goreleaser check` passes.
- Document the intentional split between GoReleaser (any tag) and ko (`v*` only) in `AGENTS.md`.

Part of #71.

## Test plan

- [x] `goreleaser check`
- [x] `make lint`
- [x] `make test`


Made with [Cursor](https://cursor.com)