### PR TITLE
Fix PROFILE parameter file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ $ execspansql ${DATABASE_ID} --query-mode=PLAN \
 
 ```yaml
 # params.yaml
-arr: ARRAY<STRING>
+arr: '["foo", "bar"]'
 names: '[STRUCT<FirstName STRING, LastName STRING>("John", "Doe"), ("Mary", "Sue")]'
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ $ execspansql ${DATABASE_ID} --query-mode=PLAN \
 ```yaml
 # params.yaml
 arr: '["foo", "bar"]'
-names: '[STRUCT<FirstName STRING, LastName STRING>("John", "Doe"), ("Mary", "Sue")]'
 ```
 
 ```

--- a/params/fixtures_test.go
+++ b/params/fixtures_test.go
@@ -17,7 +17,7 @@ func TestLoadParamFileFixtures(t *testing.T) {
 		{
 			file: "testdata/readme_example.yaml",
 			want: map[string]string{
-				"arr":   "ARRAY<STRING>",
+				"arr":   `["foo", "bar"]`,
 				"names": `[STRUCT<FirstName STRING, LastName STRING>("John", "Doe"), ("Mary", "Sue")]`,
 			},
 		},

--- a/params/fixtures_test.go
+++ b/params/fixtures_test.go
@@ -17,8 +17,7 @@ func TestLoadParamFileFixtures(t *testing.T) {
 		{
 			file: "testdata/readme_example.yaml",
 			want: map[string]string{
-				"arr":   `["foo", "bar"]`,
-				"names": `[STRUCT<FirstName STRING, LastName STRING>("John", "Doe"), ("Mary", "Sue")]`,
+				"arr": `["foo", "bar"]`,
 			},
 		},
 		{
@@ -107,7 +106,6 @@ func TestMergeParamsWithFixture(t *testing.T) {
 	got := MergeParams(file, map[string]string{"arr": "ARRAY<INT64>", "extra": "1"})
 	want := map[string]string{
 		"arr":   "ARRAY<INT64>",
-		"names": `[STRUCT<FirstName STRING, LastName STRING>("John", "Doe"), ("Mary", "Sue")]`,
 		"extra": "1",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/params/params_test.go
+++ b/params/params_test.go
@@ -45,3 +45,39 @@ func TestGenerateParamsPermitType(t *testing.T) {
 		t.Fatalf("expected typed null value, got %v", v.Value)
 	}
 }
+
+func TestReadmeExampleProfileParams(t *testing.T) {
+	t.Parallel()
+
+	file, err := LoadParamFile("testdata/readme_example.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// README documents --query-mode=PROFILE, which calls GenerateParams(..., false).
+	got, err := GenerateParams(file, false)
+	if err != nil {
+		t.Fatalf("GenerateParams(PROFILE) for README example: %v", err)
+	}
+
+	arr, ok := got["arr"].(spanner.GenericColumnValue)
+	if !ok {
+		t.Fatalf("arr: expected GenericColumnValue, got %T", got["arr"])
+	}
+	if arr.Type.GetCode() != sppb.TypeCode_ARRAY || arr.Type.GetArrayElementType().GetCode() != sppb.TypeCode_STRING {
+		t.Fatalf("arr type = %v, want ARRAY<STRING>", arr.Type)
+	}
+
+	names, ok := got["names"].(spanner.GenericColumnValue)
+	if !ok {
+		t.Fatalf("names: expected GenericColumnValue, got %T", got["names"])
+	}
+	if names.Type.GetCode() != sppb.TypeCode_ARRAY {
+		t.Fatalf("names type = %v, want ARRAY", names.Type)
+	}
+	st := names.Type.GetArrayElementType().GetStructType()
+	if st == nil || len(st.Fields) != 2 ||
+		st.Fields[0].GetName() != "FirstName" || st.Fields[0].GetType().GetCode() != sppb.TypeCode_STRING ||
+		st.Fields[1].GetName() != "LastName" || st.Fields[1].GetType().GetCode() != sppb.TypeCode_STRING {
+		t.Fatalf("names element type = %v, want STRUCT<FirstName STRING, LastName STRING>", names.Type.GetArrayElementType())
+	}
+}

--- a/params/params_test.go
+++ b/params/params_test.go
@@ -58,6 +58,9 @@ func TestReadmeExampleProfileParams(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateParams(PROFILE) for README example: %v", err)
 	}
+	if len(got) != 1 {
+		t.Fatalf("README PROFILE example params = %v, want exactly arr", got)
+	}
 
 	arr, ok := got["arr"].(spanner.GenericColumnValue)
 	if !ok {
@@ -66,18 +69,8 @@ func TestReadmeExampleProfileParams(t *testing.T) {
 	if arr.Type.GetCode() != sppb.TypeCode_ARRAY || arr.Type.GetArrayElementType().GetCode() != sppb.TypeCode_STRING {
 		t.Fatalf("arr type = %v, want ARRAY<STRING>", arr.Type)
 	}
-
-	names, ok := got["names"].(spanner.GenericColumnValue)
-	if !ok {
-		t.Fatalf("names: expected GenericColumnValue, got %T", got["names"])
-	}
-	if names.Type.GetCode() != sppb.TypeCode_ARRAY {
-		t.Fatalf("names type = %v, want ARRAY", names.Type)
-	}
-	st := names.Type.GetArrayElementType().GetStructType()
-	if st == nil || len(st.Fields) != 2 ||
-		st.Fields[0].GetName() != "FirstName" || st.Fields[0].GetType().GetCode() != sppb.TypeCode_STRING ||
-		st.Fields[1].GetName() != "LastName" || st.Fields[1].GetType().GetCode() != sppb.TypeCode_STRING {
-		t.Fatalf("names element type = %v, want STRUCT<FirstName STRING, LastName STRING>", names.Type.GetArrayElementType())
+	vals := arr.Value.GetListValue().GetValues()
+	if len(vals) != 2 || vals[0].GetStringValue() != "foo" || vals[1].GetStringValue() != "bar" {
+		t.Fatalf("arr values = %v, want [foo bar]", vals)
 	}
 }

--- a/params/testdata/readme_example.yaml
+++ b/params/testdata/readme_example.yaml
@@ -1,3 +1,3 @@
 # params.yaml from README (--param-file example)
-arr: ARRAY<STRING>
+arr: '["foo", "bar"]'
 names: '[STRUCT<FirstName STRING, LastName STRING>("John", "Doe"), ("Mary", "Sue")]'

--- a/params/testdata/readme_example.yaml
+++ b/params/testdata/readme_example.yaml
@@ -1,3 +1,2 @@
 # params.yaml from README (--param-file example)
 arr: '["foo", "bar"]'
-names: '[STRUCT<FirstName STRING, LastName STRING>("John", "Doe"), ("Mary", "Sue")]'


### PR DESCRIPTION
The parameter-file example used a bare `ARRAY<STRING>` type with `--query-mode=PROFILE`, so parameter conversion failed before the query could run. Use an actual array literal in the README and matching fixture, containing only `arr`, which the example query references.

Add a regression that loads the documented fixture and converts its parameters with PROFILE semantics, checking that it contains exactly `arr` with type `ARRAY<STRING>` and values `foo`, `bar`.

Validation: build, package tests, full emulator test suite, vet, and golangci-lint with Go 1.25.13 passed.
