### PR TITLE
Reject unsupported query modes for Partitioned DML

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,3 +325,4 @@ exit status 1
 
 * `--format=experimental_csv` does not run the jq pipeline; `--filter`, `--filter-file`, `--raw-output`, `--compact-output`, and `--jq-input-mode=lazy` are rejected.
 * `--raw-output` and `--compact-output` are supported only when `--format=json`.
+* `--query-mode=PLAN` and `--query-mode=PROFILE` cannot be combined with `--enable-partitioned-dml`. The Partitioned DML client path ignores query mode and would execute writes.

--- a/flags_validation_test.go
+++ b/flags_validation_test.go
@@ -288,6 +288,61 @@ func TestValidateExecutionOptions(t *testing.T) {
 			mode: partitionedDML{},
 			err:  "--jq-input-mode=lazy is not supported for partitioned DML",
 		},
+		{
+			name: "plan_allows_read_write_dml",
+			o:    opts{QueryMode: "PLAN"},
+			mode: readWrite{},
+		},
+		{
+			name: "profile_allows_read_write_dml",
+			o:    opts{QueryMode: "PROFILE"},
+			mode: readWrite{},
+		},
+		{
+			name: "plan_rejects_partitioned_dml",
+			o:    opts{EnablePartitionedDML: true, QueryMode: "PLAN"},
+			mode: partitionedDML{},
+			err:  "--query-mode=PLAN cannot be combined with --enable-partitioned-dml",
+		},
+		{
+			name: "profile_rejects_partitioned_dml",
+			o:    opts{EnablePartitionedDML: true, QueryMode: "PROFILE"},
+			mode: partitionedDML{},
+			err:  "--query-mode=PROFILE cannot be combined with --enable-partitioned-dml",
+		},
+		{
+			name: "plan_rejects_partitioned_dml_json",
+			o:    opts{EnablePartitionedDML: true, QueryMode: "PLAN", Format: "json"},
+			mode: partitionedDML{},
+			err:  "--query-mode=PLAN cannot be combined with --enable-partitioned-dml",
+		},
+		{
+			name: "profile_rejects_partitioned_dml_yaml",
+			o:    opts{EnablePartitionedDML: true, QueryMode: "PROFILE", Format: "yaml"},
+			mode: partitionedDML{},
+			err:  "--query-mode=PROFILE cannot be combined with --enable-partitioned-dml",
+		},
+		{
+			name: "plan_rejects_partitioned_dml_csv",
+			o:    opts{EnablePartitionedDML: true, QueryMode: "PLAN", Format: "experimental_csv"},
+			mode: partitionedDML{},
+			err:  "--query-mode=PLAN cannot be combined with --enable-partitioned-dml",
+		},
+		{
+			name: "normal_allows_partitioned_dml_json",
+			o:    opts{EnablePartitionedDML: true, QueryMode: "NORMAL", Format: "json"},
+			mode: partitionedDML{},
+		},
+		{
+			name: "normal_allows_partitioned_dml_yaml",
+			o:    opts{EnablePartitionedDML: true, QueryMode: "NORMAL", Format: "yaml"},
+			mode: partitionedDML{},
+		},
+		{
+			name: "normal_allows_partitioned_dml_csv",
+			o:    opts{EnablePartitionedDML: true, QueryMode: "NORMAL", Format: "experimental_csv"},
+			mode: partitionedDML{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/main.go
+++ b/main.go
@@ -219,6 +219,12 @@ func validateExecutionOptions(o opts, mode queryMode) error {
 		if _, ok := mode.(partitionedDML); !ok {
 			return fmt.Errorf("--enable-partitioned-dml can only be used with DML statements")
 		}
+		// PartitionedUpdateWithOptions does not copy QueryOptions.Mode, so PLAN
+		// and PROFILE would execute writes instead of returning a plan or profile.
+		switch o.QueryMode {
+		case "PLAN", "PROFILE":
+			return fmt.Errorf("--query-mode=%s cannot be combined with --enable-partitioned-dml", o.QueryMode)
+		}
 	}
 	if _, ok := mode.(partitionedDML); ok && o.JqInputMode == "lazy" {
 		return fmt.Errorf("--jq-input-mode=lazy is not supported for partitioned DML")

--- a/pdml_query_mode_test.go
+++ b/pdml_query_mode_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spanemuboost"
+)
+
+const pdmlQueryModeAuditSQL = "UPDATE PdmlQueryModeAudit SET V=99 WHERE TRUE"
+
+func TestPartitionedDMLQueryMode(t *testing.T) {
+	ctx := context.Background()
+	env, err := spanemuboost.RunEmulatorWithClients(ctx,
+		spanemuboost.WithSetupDDLs([]string{
+			"CREATE TABLE PdmlQueryModeAudit (Id INT64, V INT64) PRIMARY KEY (Id)",
+		}),
+		spanemuboost.WithSetupRawDMLs([]string{
+			"INSERT INTO PdmlQueryModeAudit (Id, V) VALUES (1, 10)",
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer env.Close() //nolint:errcheck
+
+	t.Setenv("SPANNER_EMULATOR_HOST", env.Emulator().URI())
+
+	cliBase := []string{
+		env.DatabaseID,
+		"--project", env.ProjectID,
+		"--instance", env.InstanceID,
+		"--sql", pdmlQueryModeAuditSQL,
+		"--enable-partitioned-dml",
+	}
+
+	for _, queryMode := range []string{"PLAN", "PROFILE"} {
+		for _, format := range []string{"json", "yaml", "experimental_csv"} {
+			queryMode := queryMode
+			format := format
+			t.Run("rejects_"+queryMode+"_"+format, func(t *testing.T) {
+				want := "--query-mode=" + queryMode + " cannot be combined with --enable-partitioned-dml"
+				err := runMain(t, append(cliBase, "--query-mode", queryMode, "--format", format))
+				if err == nil || !strings.Contains(err.Error(), want) {
+					t.Fatalf("_main() error = %v, want %q", err, want)
+				}
+				if got := readPdmlQueryModeV(t, ctx, env.Client); got != 10 {
+					t.Fatalf("stored V = %d, want 10 after %s %s rejection", got, queryMode, format)
+				}
+			})
+		}
+	}
+
+	for _, format := range []string{"json", "yaml", "experimental_csv"} {
+		format := format
+		t.Run("NORMAL_"+format+"_accepts_partitioned_dml", func(t *testing.T) {
+			setPdmlQueryModeV(t, ctx, env.Client, 10)
+			_, err := captureStdout(t, func() error {
+				return runMain(t, append(cliBase, "--query-mode", "NORMAL", "--format", format))
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := readPdmlQueryModeV(t, ctx, env.Client); got != 99 {
+				t.Fatalf("stored V = %d, want 99 after NORMAL %s PDML", got, format)
+			}
+		})
+	}
+}
+
+func runMain(t *testing.T, args []string) error {
+	t.Helper()
+	old := os.Args
+	os.Args = append([]string{"execspansql"}, args...)
+	defer func() { os.Args = old }()
+	return _main()
+}
+
+func readPdmlQueryModeV(t *testing.T, ctx context.Context, client *spanner.Client) int64 {
+	t.Helper()
+	row, err := client.Single().ReadRow(ctx, "PdmlQueryModeAudit", spanner.Key{1}, []string{"V"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var v int64
+	if err := row.Column(0, &v); err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
+func setPdmlQueryModeV(t *testing.T, ctx context.Context, client *spanner.Client, v int64) {
+	t.Helper()
+	_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
+		_, err := tx.Update(ctx, spanner.Statement{
+			SQL:    "UPDATE PdmlQueryModeAudit SET V=@v WHERE Id=1",
+			Params: map[string]any{"v": v},
+		})
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	fnErr := fn()
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String(), fnErr
+}


### PR DESCRIPTION
Reject `--query-mode=PLAN` and `PROFILE` with `--enable-partitioned-dml` before tracing or client creation. The Partitioned DML SDK path ignores query mode, so requesting PLAN previously performed writes.

Document the restriction and exercise the actual CLI flow against an isolated emulator: PLAN/PROFILE reject for JSON, YAML, and CSV, while NORMAL continues to update data. Ordinary read-write PLAN/PROFILE remains supported.

Validation: build, package tests, full emulator suite, vet, and golangci-lint with Go 1.25.13 passed.
