### PR TITLE
Preserve lazy row position across stats draining

### DIFF
--- a/jqresult/lazy.go
+++ b/jqresult/lazy.go
@@ -334,6 +334,10 @@ func (l *Lazy) Stop() {
 type lazyRowsField struct {
 	l   *Lazy
 	mat gojq.Iter
+	// pos is the number of rows this view has already emitted. When stats
+	// drain finishes the shared stream, replay must resume here instead of
+	// rewinding to cache offset zero (which would duplicate already emitted rows).
+	pos int
 }
 
 func (f *lazyRowsField) cachedRows() ([]any, error) {
@@ -489,8 +493,12 @@ func (f *lazyRowsField) Next() (any, bool) {
 	if redact || drained || f.l.rowsStreamDone {
 		if f.mat == nil {
 			rows := append([]any(nil), f.l.materializedRows...)
+			start := f.pos
 			f.l.mu.Unlock()
-			f.mat = materializedRowsIter(rows)
+			if start > len(rows) {
+				start = len(rows)
+			}
+			f.mat = materializedRowsIter(rows[start:])
 			return f.mat.Next()
 		}
 		f.l.mu.Unlock()
@@ -515,6 +523,7 @@ func (f *lazyRowsField) Next() (any, bool) {
 	}
 	f.l.mu.Lock()
 	f.l.materializedRows = append(f.l.materializedRows, v)
+	f.pos++
 	f.l.mu.Unlock()
 	return v, true
 }

--- a/jqresult/lazy_stats_test.go
+++ b/jqresult/lazy_stats_test.go
@@ -1,0 +1,149 @@
+package jqresult
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spaniter"
+)
+
+func TestLazyRowsKeepsPositionAfterStatsDrain(t *testing.T) {
+	t.Parallel()
+
+	l := newSyntheticLazy(t, 3)
+	defer l.Stop()
+	f, ok := l.rowsJQValue().(*lazyRowsField)
+	if !ok {
+		t.Fatalf("rowsJQValue type %T", l.rowsJQValue())
+	}
+
+	var got []any
+	for range 2 {
+		v, ok := f.Next()
+		if !ok {
+			t.Fatal("expected a live row before stats drain")
+		}
+		if err, isErr := v.(error); isErr {
+			t.Fatal(err)
+		}
+		got = append(got, v)
+	}
+
+	if _, err := l.statsMap(); err != nil {
+		t.Fatal(err)
+	}
+
+	for {
+		v, ok := f.Next()
+		if !ok {
+			break
+		}
+		if err, isErr := v.(error); isErr {
+			t.Fatal(err)
+		}
+		got = append(got, v)
+	}
+
+	ids := rowIDs(t, got)
+	if len(ids) != 3 || ids[0] != 1 || ids[1] != 2 || ids[2] != 3 {
+		t.Fatalf("ids after stats drain mid-iteration: got %v, want [1 2 3]", ids)
+	}
+}
+
+func TestLazyStatsInterleavedFilterIDs(t *testing.T) {
+	t.Parallel()
+
+	l := newSyntheticLazy(t, 3)
+	defer l.Stop()
+	code, err := Compile(`. as $root | [.rows[] | {row: ., stats: $root.stats}]`, InputLazy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	iter := code.Run(l)
+	v, ok := iter.Next()
+	if !ok {
+		t.Fatal("no output")
+	}
+	if err, isErr := v.(error); isErr {
+		t.Fatal(err)
+	}
+	rows, ok := v.([]any)
+	if !ok {
+		t.Fatalf("got %T", v)
+	}
+	var ids []int64
+	for _, item := range rows {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("item %T", item)
+		}
+		ids = append(ids, rowID(t, obj["row"]))
+	}
+	if len(ids) != 3 || ids[0] != 1 || ids[1] != 2 || ids[2] != 3 {
+		t.Fatalf("interleaved stats filter ids: got %v, want [1 2 3]", ids)
+	}
+}
+
+func newSyntheticLazy(t *testing.T, n int) *Lazy {
+	t.Helper()
+	i := 0
+	l := &Lazy{
+		metadataReady: true,
+		encodeStats: func(spaniter.Stats) (map[string]any, error) {
+			return map[string]any{"n": n}, nil
+		},
+	}
+	l.rows = &RowIter{
+		seqActive: true,
+		stopSeq:   func() {},
+		ioMu:      &l.ioMu,
+		pull: func() (*spanner.Row, error, bool) {
+			i++
+			if i > n {
+				return nil, nil, false
+			}
+			r, err := spanner.NewRow([]string{"id"}, []any{int64(i)})
+			return r, err, true
+		},
+		rowToJSON: RowToJSON,
+	}
+	return l
+}
+
+func rowIDs(t *testing.T, rows []any) []int64 {
+	t.Helper()
+	ids := make([]int64, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, rowID(t, row))
+	}
+	return ids
+}
+
+func rowID(t *testing.T, v any) int64 {
+	t.Helper()
+	row, ok := v.([]any)
+	if !ok || len(row) != 1 {
+		t.Fatalf("row %T %#v", v, v)
+	}
+	switch x := row[0].(type) {
+	case string:
+		n, err := strconv.ParseInt(x, 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return n
+	case json.Number:
+		n, err := x.Int64()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return n
+	case int64:
+		return x
+	default:
+		t.Fatalf("id type %T %#v", x, x)
+		return 0
+	}
+}


### PR DESCRIPTION
Reading `.stats` inside `.rows[]` drains and caches the remaining rows. The active row view previously restarted replay at offset zero, producing duplicates such as `1,1,2,3` for three rows.

Keep the emitted position of each active view and resume cached replay from that offset. Regression tests cover stats access through jq and after two directly consumed rows.

This addresses active iteration across stats draining. Fresh-view replay after partial consumption is a separate follow-up; the broader streaming work in #70 remains open.

Validation: build, package tests, full emulator suite, vet, and golangci-lint with Go 1.25.13 passed.
