### PR TITLE
Replay cached prefix for fresh lazy row views

### DIFF
--- a/jqresult/lazy.go
+++ b/jqresult/lazy.go
@@ -334,6 +334,10 @@ func (l *Lazy) Stop() {
 type lazyRowsField struct {
 	l   *Lazy
 	mat gojq.Iter
+	// pos is the number of rows this view has already emitted. When stats
+	// drain finishes the shared stream, replay must resume here instead of
+	// rewinding to cache offset zero (which would duplicate already emitted rows).
+	pos int
 }
 
 func (f *lazyRowsField) cachedRows() ([]any, error) {
@@ -489,8 +493,12 @@ func (f *lazyRowsField) Next() (any, bool) {
 	if redact || drained || f.l.rowsStreamDone {
 		if f.mat == nil {
 			rows := append([]any(nil), f.l.materializedRows...)
+			start := f.pos
 			f.l.mu.Unlock()
-			f.mat = materializedRowsIter(rows)
+			if start > len(rows) {
+				start = len(rows)
+			}
+			f.mat = materializedRowsIter(rows[start:])
 			return f.mat.Next()
 		}
 		f.l.mu.Unlock()
@@ -515,6 +523,7 @@ func (f *lazyRowsField) Next() (any, bool) {
 	}
 	f.l.mu.Lock()
 	f.l.materializedRows = append(f.l.materializedRows, v)
+	f.pos++
 	f.l.mu.Unlock()
 	return v, true
 }

--- a/jqresult/lazy.go
+++ b/jqresult/lazy.go
@@ -363,20 +363,22 @@ func (f *lazyRowsField) materializeSlice() (any, error) {
 		return f.cachedRows()
 	}
 
-	var out []any
+	// Consume remaining live rows from this view's position, then return the
+	// full cached prefix plus those rows. A captured view that already emitted
+	// some values must still report the complete array for length/index.
 	for {
 		v, ok := f.Next()
 		if !ok {
 			if err, isErr := v.(error); isErr {
 				return nil, err
 			}
-			return out, nil
+			break
 		}
 		if err, isErr := v.(error); isErr {
 			return nil, err
 		}
-		out = append(out, v)
 	}
+	return f.cachedRows()
 }
 
 func (f *lazyRowsField) JQValueType() string { return gojq.JQTypeArray }
@@ -488,25 +490,38 @@ func (f *lazyRowsField) JQValueEach() any {
 
 func (f *lazyRowsField) Next() (any, bool) {
 	f.l.mu.Lock()
-	drained := f.l.drained
-	redact := f.l.redact
-	if redact || drained || f.l.rowsStreamDone {
+	if f.l.redact {
 		if f.mat == nil {
-			rows := append([]any(nil), f.l.materializedRows...)
-			start := f.pos
 			f.l.mu.Unlock()
-			if start > len(rows) {
-				start = len(rows)
-			}
-			f.mat = materializedRowsIter(rows[start:])
+			f.mat = materializedRowsIter([]any{})
 			return f.mat.Next()
 		}
 		f.l.mu.Unlock()
 		return f.mat.Next()
 	}
+	if v, ok := f.nextCachedLocked(); ok {
+		f.l.mu.Unlock()
+		return v, true
+	}
+	if f.l.drained || f.l.rowsStreamDone {
+		f.l.mu.Unlock()
+		return nil, false
+	}
 	f.l.mu.Unlock()
 
 	f.l.ioMu.Lock()
+	f.l.mu.Lock()
+	if v, ok := f.nextCachedLocked(); ok {
+		f.l.mu.Unlock()
+		f.l.ioMu.Unlock()
+		return v, true
+	}
+	if f.l.drained || f.l.rowsStreamDone {
+		f.l.mu.Unlock()
+		f.l.ioMu.Unlock()
+		return nil, false
+	}
+	f.l.mu.Unlock()
 	v, ok := f.l.rows.nextUnlocked()
 	f.l.ioMu.Unlock()
 	if !ok {
@@ -525,6 +540,18 @@ func (f *lazyRowsField) Next() (any, bool) {
 	f.l.materializedRows = append(f.l.materializedRows, v)
 	f.pos++
 	f.l.mu.Unlock()
+	return v, true
+}
+
+// nextCachedLocked returns the next already-materialized row for this view.
+// Fresh views start at pos 0 so they replay the cached prefix before pulling
+// more live rows. Caller must hold f.l.mu.
+func (f *lazyRowsField) nextCachedLocked() (any, bool) {
+	if f.pos >= len(f.l.materializedRows) {
+		return nil, false
+	}
+	v := f.l.materializedRows[f.pos]
+	f.pos++
 	return v, true
 }
 

--- a/jqresult/lazy_replay_test.go
+++ b/jqresult/lazy_replay_test.go
@@ -1,0 +1,216 @@
+package jqresult
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spaniter"
+	"github.com/google/go-cmp/cmp"
+	"github.com/wader/gojq"
+)
+
+func TestLazyFreshViewReplaysCachedPrefixThenLive(t *testing.T) {
+	t.Parallel()
+
+	l := newSyntheticLazy(t, 3)
+	defer l.Stop()
+	first, ok := l.rowsJQValue().(*lazyRowsField)
+	if !ok {
+		t.Fatal("first view")
+	}
+	v, ok := first.Next()
+	if !ok {
+		t.Fatal("expected first row")
+	}
+	if rowID(t, v) != 1 {
+		t.Fatalf("first = %v, want 1", v)
+	}
+
+	fresh, ok := l.rowsJQValue().(*lazyRowsField)
+	if !ok {
+		t.Fatal("fresh view")
+	}
+	var ids []int64
+	for {
+		v, ok := fresh.Next()
+		if !ok {
+			break
+		}
+		if err, isErr := v.(error); isErr {
+			t.Fatal(err)
+		}
+		ids = append(ids, rowID(t, v))
+	}
+	if diff := cmp.Diff([]int64{1, 2, 3}, ids); diff != "" {
+		t.Fatalf("fresh view ids (-want +got)\n%s", diff)
+	}
+}
+
+func TestLazyFirstThenLengthAndFullArray(t *testing.T) {
+	t.Parallel()
+
+	got := runLazyFilter(t, `{first: first(.rows[]), count: (.rows|length), rest: [.rows[]]}`)
+	obj, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("got %T", got)
+	}
+	if rowID(t, obj["first"]) != 1 {
+		t.Fatalf("first = %#v, want row 1", obj["first"])
+	}
+	if count, ok := obj["count"].(int); !ok || count != 3 {
+		t.Fatalf("count = %#v (%T), want 3", obj["count"], obj["count"])
+	}
+	rest, ok := obj["rest"].([]any)
+	if !ok {
+		t.Fatalf("rest %T", obj["rest"])
+	}
+	if diff := cmp.Diff([]int64{1, 2, 3}, rowIDs(t, rest)); diff != "" {
+		t.Fatalf("rest ids (-want +got)\n%s", diff)
+	}
+}
+
+func TestLazyIndependentCapturedRowsViews(t *testing.T) {
+	t.Parallel()
+
+	got := runLazyFilter(t, `{a: [.rows[]], b: [.rows[]]}`)
+	obj, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("got %T", got)
+	}
+	for _, key := range []string{"a", "b"} {
+		rows, ok := obj[key].([]any)
+		if !ok {
+			t.Fatalf("%s %T", key, obj[key])
+		}
+		if diff := cmp.Diff([]int64{1, 2, 3}, rowIDs(t, rows)); diff != "" {
+			t.Fatalf("%s ids (-want +got)\n%s", key, diff)
+		}
+	}
+}
+
+func TestLazyCapturedViewFirstThenLength(t *testing.T) {
+	t.Parallel()
+
+	got := runLazyFilter(t, `.rows as $r | {first: first($r[]), count: ($r|length)}`)
+	obj, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("got %T", got)
+	}
+	if rowID(t, obj["first"]) != 1 {
+		t.Fatalf("first = %#v, want row 1", obj["first"])
+	}
+	if count, ok := obj["count"].(int); !ok || count != 3 {
+		t.Fatalf("count = %#v (%T), want 3", obj["count"], obj["count"])
+	}
+}
+
+func TestLazyRedactRowsViews(t *testing.T) {
+	t.Parallel()
+
+	l := newSyntheticLazy(t, 3)
+	l.redact = true
+	l.rows.redact = true
+	defer l.Stop()
+
+	code, err := Compile("{n: (.rows|length), rows: [.rows[]]}", InputLazy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := firstJQValue(t, code.Run(l))
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("got %T", v)
+	}
+	if count, ok := obj["n"].(int); !ok || count != 0 {
+		t.Fatalf("redact length = %#v, want 0", obj["n"])
+	}
+	rows, ok := obj["rows"].([]any)
+	if !ok || len(rows) != 0 {
+		t.Fatalf("redact rows = %#v, want empty", obj["rows"])
+	}
+}
+
+func TestLazyReplayLiveError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("row boom")
+	i := 0
+	l := &Lazy{
+		metadataReady: true,
+		encodeStats: func(spaniter.Stats) (map[string]any, error) {
+			return map[string]any{"n": 1}, nil
+		},
+	}
+	l.rows = &RowIter{
+		seqActive: true,
+		stopSeq:   func() {},
+		ioMu:      &l.ioMu,
+		pull: func() (*spanner.Row, error, bool) {
+			i++
+			if i == 1 {
+				r, err := spanner.NewRow([]string{"id"}, []any{int64(1)})
+				return r, err, true
+			}
+			return nil, wantErr, false
+		},
+		rowToJSON: RowToJSON,
+	}
+	defer l.Stop()
+
+	first, ok := l.rowsJQValue().(*lazyRowsField)
+	if !ok {
+		t.Fatal("first view")
+	}
+	if _, ok := first.Next(); !ok {
+		t.Fatal("expected first row")
+	}
+
+	fresh, ok := l.rowsJQValue().(*lazyRowsField)
+	if !ok {
+		t.Fatal("fresh view")
+	}
+	v, ok := fresh.Next()
+	if !ok || rowID(t, v) != 1 {
+		t.Fatalf("fresh prefix = %#v ok=%v, want row 1", v, ok)
+	}
+	v, ok = fresh.Next()
+	if !ok {
+		t.Fatal("expected error from live pull")
+	}
+	err, isErr := v.(error)
+	if !isErr || !errors.Is(err, wantErr) {
+		t.Fatalf("live error = %#v, want %v", v, wantErr)
+	}
+}
+
+func runLazyFilter(t *testing.T, filter string) any {
+	t.Helper()
+	l := newSyntheticLazy(t, 3)
+	defer l.Stop()
+	code, err := Compile(filter, InputLazy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := firstJQValue(t, code.Run(l))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
+func firstJQValue(t *testing.T, iter gojq.Iter) (any, error) {
+	t.Helper()
+	v, ok := iter.Next()
+	if !ok {
+		return nil, fmt.Errorf("no output")
+	}
+	if err, isErr := v.(error); isErr {
+		return nil, err
+	}
+	return v, nil
+}

--- a/jqresult/lazy_stats_test.go
+++ b/jqresult/lazy_stats_test.go
@@ -1,0 +1,149 @@
+package jqresult
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spaniter"
+)
+
+func TestLazyRowsKeepsPositionAfterStatsDrain(t *testing.T) {
+	t.Parallel()
+
+	l := newSyntheticLazy(t, 3)
+	defer l.Stop()
+	f, ok := l.rowsJQValue().(*lazyRowsField)
+	if !ok {
+		t.Fatalf("rowsJQValue type %T", l.rowsJQValue())
+	}
+
+	var got []any
+	for range 2 {
+		v, ok := f.Next()
+		if !ok {
+			t.Fatal("expected a live row before stats drain")
+		}
+		if err, isErr := v.(error); isErr {
+			t.Fatal(err)
+		}
+		got = append(got, v)
+	}
+
+	if _, err := l.statsMap(); err != nil {
+		t.Fatal(err)
+	}
+
+	for {
+		v, ok := f.Next()
+		if !ok {
+			break
+		}
+		if err, isErr := v.(error); isErr {
+			t.Fatal(err)
+		}
+		got = append(got, v)
+	}
+
+	ids := rowIDs(t, got)
+	if len(ids) != 3 || ids[0] != 1 || ids[1] != 2 || ids[2] != 3 {
+		t.Fatalf("ids after stats drain mid-iteration: got %v, want [1 2 3]", ids)
+	}
+}
+
+func TestLazyStatsInterleavedFilterIDs(t *testing.T) {
+	t.Parallel()
+
+	l := newSyntheticLazy(t, 3)
+	defer l.Stop()
+	code, err := Compile(`. as $root | [.rows[] | {row: ., stats: $root.stats}]`, InputLazy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	iter := code.Run(l)
+	v, ok := iter.Next()
+	if !ok {
+		t.Fatal("no output")
+	}
+	if err, isErr := v.(error); isErr {
+		t.Fatal(err)
+	}
+	rows, ok := v.([]any)
+	if !ok {
+		t.Fatalf("got %T", v)
+	}
+	var ids []int64
+	for _, item := range rows {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("item %T", item)
+		}
+		ids = append(ids, rowID(t, obj["row"]))
+	}
+	if len(ids) != 3 || ids[0] != 1 || ids[1] != 2 || ids[2] != 3 {
+		t.Fatalf("interleaved stats filter ids: got %v, want [1 2 3]", ids)
+	}
+}
+
+func newSyntheticLazy(t *testing.T, n int) *Lazy {
+	t.Helper()
+	i := 0
+	l := &Lazy{
+		metadataReady: true,
+		encodeStats: func(spaniter.Stats) (map[string]any, error) {
+			return map[string]any{"n": n}, nil
+		},
+	}
+	l.rows = &RowIter{
+		seqActive: true,
+		stopSeq:   func() {},
+		ioMu:      &l.ioMu,
+		pull: func() (*spanner.Row, error, bool) {
+			i++
+			if i > n {
+				return nil, nil, false
+			}
+			r, err := spanner.NewRow([]string{"id"}, []any{int64(i)})
+			return r, err, true
+		},
+		rowToJSON: RowToJSON,
+	}
+	return l
+}
+
+func rowIDs(t *testing.T, rows []any) []int64 {
+	t.Helper()
+	ids := make([]int64, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, rowID(t, row))
+	}
+	return ids
+}
+
+func rowID(t *testing.T, v any) int64 {
+	t.Helper()
+	row, ok := v.([]any)
+	if !ok || len(row) != 1 {
+		t.Fatalf("row %T %#v", v, v)
+	}
+	switch x := row[0].(type) {
+	case string:
+		n, err := strconv.ParseInt(x, 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return n
+	case json.Number:
+		n, err := x.Int64()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return n
+	case int64:
+		return x
+	default:
+		t.Fatalf("id type %T %#v", x, x)
+		return 0
+	}
+}


### PR DESCRIPTION
After `first(.rows[])`, a fresh lazy rows view previously skipped the cached prefix: a three-row result reported length two or returned only rows two and three.

Replay cached rows from each view's own position before reading additional rows. Array materialization returns the complete cache, including values already consumed through the same captured view. Add regressions for partial reads, captured views, redaction, and errors after the cached prefix.

Builds on the active-cursor stats-drain fix merged in #82. This PR targets main and contains only the fresh-view replay fix; the broader streaming work in #70 stays open.

Validation: build, package tests, full emulator suite, vet, and golangci-lint with Go 1.25.13 passed locally. Go and lint workflows run on the updated main-targeting PR head.
