### PR TITLE
Support fully qualified database resource names

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,22 @@ This tool is still pre-release quality and none of guarantees.
 
 You can use [released binaries](https://github.com/apstndb/execspansql/releases).
 ```
-Usage: execspansql --sql=STRING --sql-file=STRING --project=STRING --instance=STRING <database> [flags]
+Usage: execspansql --sql=STRING --sql-file=STRING <database> [flags]
 
 Yet another gcloud spanner databases execute-sql replacement
 
 Arguments:
-  <database>    ID of the database.
+  <database>    ID or fully qualified resource name of the database.
 
 Flags:
   -h, --help                       Show context-sensitive help.
       --sql=STRING                 SQL query text; exclusive with --sql-file.
       --sql-file=STRING            File name contains SQL query; exclusive with
                                    --sql
-  -p, --project=STRING             ID of the project ($CLOUDSDK_CORE_PROJECT).
-  -i, --instance=STRING            ID of the instance
-                                   ($CLOUDSDK_SPANNER_INSTANCE).
+  -p, --project=STRING             ID of the project; required for a database ID
+                                   ($CLOUDSDK_CORE_PROJECT).
+  -i, --instance=STRING            ID of the instance; required for a database
+                                   ID ($CLOUDSDK_SPANNER_INSTANCE).
       --query-mode="NORMAL"        Query mode.
       --format="json"              Output format.
       --redact-rows                Redact result rows from output
@@ -90,6 +91,16 @@ $ docker run --rm -t -v "${HOME}/.config/gcloud/application_default_credentials.
 $ docker run --rm -t -v "${HOME}/.config/gcloud/application_default_credentials.json:/home/nonroot/.config/gcloud/application_default_credentials.json:ro" \
     ghcr.io/apstndb/execspansql/execspansql:vX.Y.Z -p ${SPANNER_PROJECT} -i ${SPANNER_INSTANCE} ${SPANNER_DATABASE} --sql 'SELECT 1'
 ```
+
+## Database resource names
+
+Pass either a database ID with `--project` and `--instance`, or a fully qualified resource name:
+
+```sh
+execspansql projects/my-project/instances/my-instance/databases/my-database --sql='SELECT 1'
+```
+
+A fully qualified name supplies all three IDs and takes precedence over `--project`, `--instance`, and their `CLOUDSDK_CORE_PROJECT` / `CLOUDSDK_SPANNER_INSTANCE` environment defaults. A short database ID still requires project and instance flags or environment values. As before, gcloud configuration files are not read.
 
 ## Notable features
 

--- a/database_resource_test.go
+++ b/database_resource_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/apstndb/spanemuboost"
+)
+
+func TestDatabaseResourceName(t *testing.T) {
+	t.Parallel()
+	const full = "projects/project/instances/instance/databases/database"
+	for _, tt := range []struct {
+		name, project, instance, database, want, err string
+	}{
+		{name: "IDs", project: "project", instance: "instance", database: "database", want: full},
+		{name: "full_name", database: full, want: full},
+		{name: "full_name_overrides_defaults", project: "other-project", instance: "other-instance", database: full, want: full},
+		{name: "missing_database", err: "database ID is required"},
+		{name: "missing_project", database: "database", instance: "instance", err: "--project is required"},
+		{name: "missing_instance", database: "database", project: "project", err: "--instance is required"},
+		{name: "project_path", project: "projects/project", instance: "instance", database: "database", err: "must be IDs"},
+		{name: "instance_path", project: "project", instance: "instances/instance", database: "database", err: "must be IDs"},
+		{name: "partial_name", database: "instances/instance/databases/database", err: "invalid database resource name"},
+		{name: "empty_project", database: "projects//instances/instance/databases/database", err: "invalid database resource name"},
+		{name: "empty_instance", database: "projects/project/instances//databases/database", err: "invalid database resource name"},
+		{name: "empty_database", database: "projects/project/instances/instance/databases/", err: "invalid database resource name"},
+		{name: "wrong_collection", database: "projects/project/instances/instance/tables/database", err: "invalid database resource name"},
+		{name: "extra_segment", database: full + "/table", err: "invalid database resource name"},
+		{name: "leading_slash", database: "/" + full, err: "invalid database resource name"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := databaseResourceName(tt.project, tt.instance, tt.database)
+			if tt.err != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.err) {
+					t.Fatalf("got %q, %v; want error containing %q", got, err, tt.err)
+				}
+				return
+			}
+			if err != nil || got != tt.want {
+				t.Fatalf("got %q, %v; want %q", got, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestDatabaseResourceIntegration(t *testing.T) {
+	env, err := spanemuboost.RunEmulatorWithClients(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer env.Close() //nolint:errcheck
+	t.Setenv("SPANNER_EMULATOR_HOST", env.Emulator().URI())
+	t.Setenv("CLOUDSDK_CORE_PROJECT", "other-project")
+	t.Setenv("CLOUDSDK_SPANNER_INSTANCE", "other-instance")
+	full, err := databaseResourceName(env.ProjectID, env.InstanceID, env.DatabaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, flags := range [][]string{nil, {"--project=another-project", "--instance=another-instance"}} {
+		output, err := captureStdout(t, func() error {
+			return runMain(t, append([]string{full, "--sql=SELECT 12345 AS n"}, flags...))
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var result struct {
+			Rows [][]string `json:"rows"`
+		}
+		if err := json.Unmarshal([]byte(output), &result); err != nil {
+			t.Fatal(err)
+		}
+		if len(result.Rows) != 1 || len(result.Rows[0]) != 1 || result.Rows[0][0] != "12345" {
+			t.Fatalf("unexpected query result: %s", output)
+		}
+	}
+}
+
+func TestDatabaseResourceFlags(t *testing.T) {
+	const full = "projects/project/instances/instance/databases/database"
+	for _, tt := range []struct {
+		name, projectEnv, instanceEnv string
+		args                          []string
+		want, err                     string
+	}{
+		{name: "full_name_only", args: []string{full}, want: full},
+		{name: "full_name_overrides_flags", args: []string{full, "--project=other", "--instance=other"}, want: full},
+		{name: "full_name_overrides_env", projectEnv: "other", instanceEnv: "other", args: []string{full}, want: full},
+		{name: "short_name_with_flags", args: []string{"database", "-p", "project", "-i", "instance"}, want: full},
+		{name: "short_name_with_env", projectEnv: "project", instanceEnv: "instance", args: []string{"database"}, want: full},
+		{name: "flags_override_env", projectEnv: "other", instanceEnv: "other", args: []string{"database", "-p", "project", "-i", "instance"}, want: full},
+		{name: "missing_project", args: []string{"database", "-i", "instance"}, err: "--project is required"},
+		{name: "missing_instance", args: []string{"database", "-p", "project"}, err: "--instance is required"},
+		{name: "malformed_name", args: []string{"projects/project/databases/database"}, err: "invalid database resource name"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CLOUDSDK_CORE_PROJECT", tt.projectEnv)
+			t.Setenv("CLOUDSDK_SPANNER_INSTANCE", tt.instanceEnv)
+			var o opts
+			parser, err := kong.New(&o)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = parser.Parse(append(append([]string{}, tt.args...), "--sql=SELECT 1"))
+			if tt.err != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.err) {
+					t.Fatalf("Parse() error = %v; want %q", err, tt.err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := databaseResourceName(o.Project, o.Instance, o.Database)
+			if err != nil || got != tt.want {
+				t.Fatalf("parsed resource = %q, %v; want %q", got, err, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -48,11 +48,11 @@ func main() {
 }
 
 type opts struct {
-	Database             string        `arg:"" required:"" help:"ID of the database."`
+	Database             string        `arg:"" required:"" help:"ID or fully qualified resource name of the database."`
 	Sql                  string        `name:"sql" xor:"sql" required:"" help:"SQL query text; exclusive with --sql-file."`
 	SqlFile              string        `name:"sql-file" xor:"sql" required:"" help:"File name contains SQL query; exclusive with --sql"`
-	Project              string        `name:"project" short:"p" env:"CLOUDSDK_CORE_PROJECT" required:"" help:"ID of the project."`
-	Instance             string        `name:"instance" short:"i" env:"CLOUDSDK_SPANNER_INSTANCE" required:"" help:"ID of the instance."`
+	Project              string        `name:"project" short:"p" env:"CLOUDSDK_CORE_PROJECT" help:"ID of the project; required for a database ID."`
+	Instance             string        `name:"instance" short:"i" env:"CLOUDSDK_SPANNER_INSTANCE" help:"ID of the instance; required for a database ID."`
 	QueryMode            string        `name:"query-mode" enum:"NORMAL,PLAN,PROFILE" default:"NORMAL" help:"Query mode."`
 	Format               string        `name:"format" enum:"json,yaml,experimental_csv" default:"json" help:"Output format."`
 	RedactRows           bool          `name:"redact-rows" help:"Redact result rows from output"`
@@ -75,6 +75,37 @@ type opts struct {
 		Strong        bool   `name:"strong" xor:"timestamp" help:"Perform a strong query."`
 		ReadTimestamp string `name:"read-timestamp" xor:"timestamp" help:"Perform a query at the given timestamp. (micro-seconds precision)"`
 	} `embed:"" prefix:"" group:"Timestamp Bound"`
+}
+
+func (o opts) Validate() error {
+	_, err := databaseResourceName(o.Project, o.Instance, o.Database)
+	return err
+}
+
+func databaseResourceName(project, instance, database string) (string, error) {
+	if strings.Contains(database, "/") {
+		parts := strings.Split(database, "/")
+		if len(parts) != 6 || parts[0] != "projects" || parts[1] == "" ||
+			parts[2] != "instances" || parts[3] == "" || parts[4] != "databases" || parts[5] == "" {
+			return "", fmt.Errorf("invalid database resource name %q; expected projects/PROJECT/instances/INSTANCE/databases/DATABASE", database)
+		}
+		// Like gcloud resource arguments, an explicit full name takes precedence
+		// over project and instance flags or environment defaults.
+		return database, nil
+	}
+	if database == "" {
+		return "", errors.New("database ID is required")
+	}
+	if project == "" {
+		return "", errors.New("--project is required when database is an ID")
+	}
+	if instance == "" {
+		return "", errors.New("--instance is required when database is an ID")
+	}
+	if strings.ContainsAny(project+instance, "/") {
+		return "", errors.New("--project and --instance must be IDs, not resource names")
+	}
+	return fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, instance, database), nil
 }
 
 func (o opts) mergedParams() (map[string]string, error) {
@@ -547,7 +578,10 @@ func writeCsvFromResultSet(writer io.Writer, rs *sppb.ResultSet) error {
 }
 
 func newClient(ctx context.Context, project, instance, database string, logGrpcMode string, doTrace bool) (*spanner.Client, error) {
-	name := fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, instance, database)
+	name, err := databaseResourceName(project, instance, database)
+	if err != nil {
+		return nil, err
+	}
 
 	var copts []option.ClientOption
 	if logGrpcMode != logGrpcModeOff {


### PR DESCRIPTION
Accept `projects/PROJECT/instances/INSTANCE/databases/DATABASE` as the database argument so callers can execute a query without repeating project and instance flags. The full name takes precedence over flags and environment defaults, matching gcloud resource selection. Short database IDs still require project and instance, and malformed resource paths fail during flag validation.

Tests cover flag/environment precedence, malformed names, and actual queries against the emulator with conflicting defaults. The README help and usage example reflect the new form.

Validation: `go test ./...` (Colima emulator), `go build ./...`, `golangci-lint run --timeout=5m` (0 issues), `git diff --check`, and generated CLI help comparison, using Go 1.25.13.
