### PR TITLE
Support Spanner database roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Flags:
   -p, --project=STRING             ID of the project ($CLOUDSDK_CORE_PROJECT).
   -i, --instance=STRING            ID of the instance
                                    ($CLOUDSDK_SPANNER_INSTANCE).
+      --database-role=STRING       Database role to assume for all operations.
       --query-mode="NORMAL"        Query mode.
       --format="json"              Output format.
       --redact-rows                Redact result rows from output
@@ -94,6 +95,15 @@ $ docker run --rm -t -v "${HOME}/.config/gcloud/application_default_credentials.
 ## Notable features
 
 There are examples omitting some required options.
+
+### Database role
+
+Use `--database-role` to assume a Spanner database role for every operation in the command:
+
+```
+$ execspansql ${DATABASE_ID} --project=${SPANNER_PROJECT} --instance=${SPANNER_INSTANCE} \
+    --database-role=report_reader --sql='SELECT * FROM Singers'
+```
 
 ### Parameter support
 

--- a/database_role_test.go
+++ b/database_role_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/alecthomas/kong"
+	"google.golang.org/grpc"
+)
+
+type databaseRoleSpannerServer struct {
+	sppb.UnimplementedSpannerServer
+	createSession chan *sppb.CreateSessionRequest
+}
+
+func (s *databaseRoleSpannerServer) CreateSession(_ context.Context, req *sppb.CreateSessionRequest) (*sppb.Session, error) {
+	s.createSession <- req
+	return &sppb.Session{
+		Name:        req.Database + "/sessions/test",
+		CreatorRole: req.GetSession().GetCreatorRole(),
+		Multiplexed: true,
+	}, nil
+}
+
+func TestDatabaseRoleFlag(t *testing.T) {
+	t.Parallel()
+
+	var got opts
+	parser, err := kong.New(&got, kong.Name("execspansql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = parser.Parse([]string{
+		"db", "--project", "p", "--instance", "i", "--sql", "SELECT 1",
+		"--database-role", "report_reader",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.DatabaseRole != "report_reader" {
+		t.Fatalf("DatabaseRole = %q, want %q", got.DatabaseRole, "report_reader")
+	}
+}
+
+func TestNewClientSendsDatabaseRoleWhenCreatingSession(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		role string
+	}{
+		{name: "set", role: "report_reader"},
+		{name: "omitted"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &databaseRoleSpannerServer{createSession: make(chan *sppb.CreateSessionRequest, 1)}
+			grpcServer := grpc.NewServer()
+			sppb.RegisterSpannerServer(grpcServer, server)
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				grpcServer.Stop()
+				_ = listener.Close()
+			})
+			go func() { _ = grpcServer.Serve(listener) }()
+			t.Setenv("SPANNER_EMULATOR_HOST", listener.Addr().String())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			client, err := newClient(ctx, "p", "i", "d", tt.role, logGrpcModeOff, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer client.Close()
+
+			select {
+			case req := <-server.createSession:
+				if got := req.GetSession().GetCreatorRole(); got != tt.role {
+					t.Fatalf("session CreatorRole = %q, want %q", got, tt.role)
+				}
+			case <-ctx.Done():
+				t.Fatalf("CreateSession was not called: %v", ctx.Err())
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ type opts struct {
 	SqlFile              string        `name:"sql-file" xor:"sql" required:"" help:"File name contains SQL query; exclusive with --sql"`
 	Project              string        `name:"project" short:"p" env:"CLOUDSDK_CORE_PROJECT" required:"" help:"ID of the project."`
 	Instance             string        `name:"instance" short:"i" env:"CLOUDSDK_SPANNER_INSTANCE" required:"" help:"ID of the instance."`
+	DatabaseRole         string        `name:"database-role" help:"Database role to assume for all operations."`
 	QueryMode            string        `name:"query-mode" enum:"NORMAL,PLAN,PROFILE" default:"NORMAL" help:"Query mode."`
 	Format               string        `name:"format" enum:"json,yaml,experimental_csv" default:"json" help:"Output format."`
 	RedactRows           bool          `name:"redact-rows" help:"Redact result rows from output"`
@@ -417,7 +418,7 @@ func _main() error {
 		}()
 	}
 
-	client, err := newClient(ctx, o.Project, o.Instance, o.Database, o.LogGrpc, tracingEnabled(o))
+	client, err := newClient(ctx, o.Project, o.Instance, o.Database, o.DatabaseRole, o.LogGrpc, tracingEnabled(o))
 	if err != nil {
 		return err
 	}
@@ -546,7 +547,7 @@ func writeCsvFromResultSet(writer io.Writer, rs *sppb.ResultSet) error {
 	return csvWriter.Flush()
 }
 
-func newClient(ctx context.Context, project, instance, database string, logGrpcMode string, doTrace bool) (*spanner.Client, error) {
+func newClient(ctx context.Context, project, instance, database, databaseRole string, logGrpcMode string, doTrace bool) (*spanner.Client, error) {
 	name := fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, instance, database)
 
 	var copts []option.ClientOption
@@ -557,8 +558,7 @@ func newClient(ctx context.Context, project, instance, database string, logGrpcM
 	if doTrace {
 		copts = append(copts, option.WithGRPCDialOption(grpc.WithChainStreamInterceptor(interceptor.StreamInterceptor(interceptor.WithDefaultDecorators()))))
 	}
-
-	return spanner.NewClientWithConfig(ctx, name, spanner.ClientConfig{}, copts...)
+	return spanner.NewClientWithConfig(ctx, name, spanner.ClientConfig{DatabaseRole: databaseRole}, copts...)
 }
 
 type encoder interface {


### PR DESCRIPTION
Add `--database-role` to run queries and other database operations with a Spanner database role, matching the execute-sql option. The role is passed to the shared Spanner client configuration; omitting the flag preserves the existing behavior.

Tests cover flag parsing and capture the actual session-creation RPC for supplied and omitted roles. README help and usage are updated. The local transport test verifies role propagation; it does not validate managed Spanner role grants or permission enforcement.

Validation: `go test ./...` (including emulator integration tests), `go build ./...`, `golangci-lint run --timeout=5m` (0 issues), `git diff --check`, and generated CLI help comparison with Go 1.25.13.
