### PR TITLE
Support execute SQL request priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Flags:
   -i, --instance=STRING            ID of the instance
                                    ($CLOUDSDK_SPANNER_INSTANCE).
       --query-mode="NORMAL"        Query mode.
+      --priority="unspecified"     Priority for the execute SQL request.
       --format="json"              Output format.
       --redact-rows                Redact result rows from output
   -c, --compact-output             Compact JSON output (--compact-output of jq)
@@ -302,13 +303,17 @@ Note: `--log-grpc=payload` can log request and response payloads (including boun
 
 ![trace.png](docs/trace.png)
 
+### Request priority
+
+Use `--priority=high`, `--priority=medium`, `--priority=low`, or `--priority=unspecified` to set the Spanner execute-SQL request priority. Omitting the flag keeps the unspecified priority. The setting applies to JSON/YAML output (including eager and lazy jq input), CSV, ordinary DML, and Partitioned DML; it does not change read-write transaction commit priority.
+
 ### (Experimental) `--try-partition-query`
 
 Check whether the query can be executed as partition query or not.
 
 By default this checks against the current schema using a strong read. Pass `--read-timestamp` to check partitionability against a historical schema within the database version retention window.
 
-`--try-partition-query` is a query-routing check and rejects jq-related options (`--filter`, `--filter-file`, `--raw-output`, `--compact-output`) and `--jq-input-mode=lazy`.
+`--try-partition-query` is a query-routing check and rejects jq-related options (`--filter`, `--filter-file`, `--raw-output`, `--compact-output`) and `--jq-input-mode=lazy`. It also rejects `--priority=high`, `--priority=medium`, and `--priority=low`: the pinned Spanner Go client cannot put priority on its `PartitionQuery` request, and this check does not execute the returned partitions.
 
 ```
 $ execspansql ${DATABASE_ID} --sql='SELECT * FROM Singers JOIN Albums USING(SingerId)' --try-partition-query

--- a/flags_validation_test.go
+++ b/flags_validation_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/execspansql/jqresult"
 	"go.uber.org/zap"
 )
@@ -218,6 +220,12 @@ func TestValidateExecutionOptions(t *testing.T) {
 			mode: single{spanner.StrongRead()},
 		},
 		{
+			name: "try_partition_rejects_priority",
+			o:    opts{TryPartitionQuery: true, Priority: "high"},
+			mode: single{spanner.StrongRead()},
+			err:  "--priority cannot be used with --try-partition-query",
+		},
+		{
 			name: "try_partition_rejects_dml",
 			o:    opts{TryPartitionQuery: true},
 			mode: readWrite{},
@@ -416,6 +424,73 @@ func TestQueryModeForQuery(t *testing.T) {
 				if s.String() != tt.tb.String() {
 					t.Fatalf("queryModeForQuery() tb = %q, want %q", s.String(), tt.tb.String())
 				}
+			}
+		})
+	}
+}
+
+func TestQueryOptionsForPriority(t *testing.T) {
+	t.Parallel()
+
+	mode := sppb.ExecuteSqlRequest_PROFILE
+	tests := []struct {
+		name     string
+		priority string
+		want     sppb.RequestOptions_Priority
+	}{
+		{name: "high", priority: "high", want: sppb.RequestOptions_PRIORITY_HIGH},
+		{name: "low", priority: "low", want: sppb.RequestOptions_PRIORITY_LOW},
+		{name: "medium", priority: "medium", want: sppb.RequestOptions_PRIORITY_MEDIUM},
+		{name: "unspecified", priority: "unspecified", want: sppb.RequestOptions_PRIORITY_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := queryOptionsFor(mode, tt.priority)
+			if got.Mode == nil || *got.Mode != mode {
+				t.Fatalf("query options mode = %v, want %v", got.Mode, mode)
+			}
+			if got.Priority != tt.want {
+				t.Fatalf("query options priority = %v, want %v", got.Priority, tt.want)
+			}
+		})
+	}
+}
+
+func TestProcessFlagsPriority(t *testing.T) {
+	oldArgs := os.Args
+	t.Cleanup(func() { os.Args = oldArgs })
+
+	baseArgs := []string{"execspansql", "database", "--project", "project", "--instance", "instance", "--sql", "SELECT 1"}
+	tests := []struct {
+		name    string
+		args    []string
+		want    string
+		wantErr string
+	}{
+		{name: "default", args: baseArgs, want: "unspecified"},
+		{name: "high", args: append(baseArgs, "--priority", "high"), want: "high"},
+		{name: "low", args: append(baseArgs, "--priority", "low"), want: "low"},
+		{name: "medium", args: append(baseArgs, "--priority", "medium"), want: "medium"},
+		{name: "unspecified", args: append(baseArgs, "--priority", "unspecified"), want: "unspecified"},
+		{name: "invalid", args: append(baseArgs, "--priority", "urgent"), wantErr: "--priority must be one of"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Args = tt.args
+			got, err := processFlags()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("processFlags() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Priority != tt.want {
+				t.Fatalf("priority = %q, want %q", got.Priority, tt.want)
 			}
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ type opts struct {
 	Project              string        `name:"project" short:"p" env:"CLOUDSDK_CORE_PROJECT" required:"" help:"ID of the project."`
 	Instance             string        `name:"instance" short:"i" env:"CLOUDSDK_SPANNER_INSTANCE" required:"" help:"ID of the instance."`
 	QueryMode            string        `name:"query-mode" enum:"NORMAL,PLAN,PROFILE" default:"NORMAL" help:"Query mode."`
+	Priority             string        `name:"priority" enum:"high,low,medium,unspecified" default:"unspecified" help:"Priority for the execute SQL request."`
 	Format               string        `name:"format" enum:"json,yaml,experimental_csv" default:"json" help:"Output format."`
 	RedactRows           bool          `name:"redact-rows" help:"Redact result rows from output"`
 	CompactOutput        bool          `name:"compact-output" short:"c" help:"Compact JSON output (--compact-output of jq)"`
@@ -202,6 +203,13 @@ func validateExecutionOptions(o opts, mode queryMode) error {
 			}
 			return fmt.Errorf("--try-partition-query cannot be used with DML statements")
 		}
+		if o.Priority != "" && o.Priority != "unspecified" {
+			// The v1.90.0 client only puts QueryOptions.Priority on ExecuteSqlRequest
+			// objects returned for later partition execution. This probe only calls
+			// PartitionQuery, whose request has no priority field, so accepting the
+			// flag here would silently drop it.
+			return fmt.Errorf("--priority cannot be used with --try-partition-query")
+		}
 	}
 	if o.TimestampBound.ReadTimestamp != "" || o.TimestampBound.Strong {
 		if _, ok := mode.(single); !ok {
@@ -304,6 +312,16 @@ func (s single) isQueryMode()         {}
 func (r readWrite) isQueryMode()      {}
 func (p partitionedDML) isQueryMode() {}
 
+func queryOptionsFor(mode sppb.ExecuteSqlRequest_QueryMode, priority string) spanner.QueryOptions {
+	priorities := map[string]sppb.RequestOptions_Priority{
+		"high":        sppb.RequestOptions_PRIORITY_HIGH,
+		"low":         sppb.RequestOptions_PRIORITY_LOW,
+		"medium":      sppb.RequestOptions_PRIORITY_MEDIUM,
+		"unspecified": sppb.RequestOptions_PRIORITY_UNSPECIFIED,
+	}
+	return spanner.QueryOptions{Mode: &mode, Priority: priorities[priority]}
+}
+
 // dmlRowCountForMode reports whether read-write results should encode exact DML
 // row counts. PLAN mode returns false because execution does not produce a count.
 func dmlRowCountForMode(mode queryMode, opts spanner.QueryOptions) bool {
@@ -389,6 +407,7 @@ func _main() error {
 	}
 
 	mode := sppb.ExecuteSqlRequest_QueryMode(sppb.ExecuteSqlRequest_QueryMode_value[o.QueryMode])
+	queryOpts := queryOptionsFor(mode, o.Priority)
 
 	query, err := readFileOrDefault(o.SqlFile, o.Sql)
 	if err != nil {
@@ -452,10 +471,10 @@ func _main() error {
 	}
 
 	if o.Format == "experimental_csv" {
-		return runAndWriteCsv(ctx, client, stmt, spanner.QueryOptions{Mode: &mode}, m, o.RedactRows)
+		return runAndWriteCsv(ctx, client, stmt, queryOpts, m, o.RedactRows)
 	}
 
-	return runJqOutput(ctx, client, stmt, spanner.QueryOptions{Mode: &mode}, m, o, jqMode, jqCode)
+	return runJqOutput(ctx, client, stmt, queryOpts, m, o, jqMode, jqCode)
 }
 
 func runAndWriteCsv(ctx context.Context, client *spanner.Client, stmt spanner.Statement, opts spanner.QueryOptions, mode queryMode, redactRows bool) error {

--- a/priority_transport_test.go
+++ b/priority_transport_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type priorityRecordingSpannerServer struct {
+	sppb.UnimplementedSpannerServer
+	requests chan *sppb.ExecuteSqlRequest
+}
+
+func (s *priorityRecordingSpannerServer) CreateSession(_ context.Context, req *sppb.CreateSessionRequest) (*sppb.Session, error) {
+	return &sppb.Session{Name: req.Database + "/sessions/priority-test"}, nil
+}
+
+func (*priorityRecordingSpannerServer) BeginTransaction(context.Context, *sppb.BeginTransactionRequest) (*sppb.Transaction, error) {
+	return &sppb.Transaction{Id: []byte("priority-test")}, nil
+}
+
+func (s *priorityRecordingSpannerServer) ExecuteStreamingSql(req *sppb.ExecuteSqlRequest, _ sppb.Spanner_ExecuteStreamingSqlServer) error {
+	s.requests <- req
+	return status.Error(codes.InvalidArgument, "priority test capture")
+}
+
+func (s *priorityRecordingSpannerServer) ExecuteSql(_ context.Context, req *sppb.ExecuteSqlRequest) (*sppb.ResultSet, error) {
+	s.requests <- req
+	return nil, status.Error(codes.InvalidArgument, "priority test capture")
+}
+
+func startPriorityRecordingSpannerServer(t *testing.T) (*priorityRecordingSpannerServer, string) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := grpc.NewServer()
+	recorder := &priorityRecordingSpannerServer{requests: make(chan *sppb.ExecuteSqlRequest, 1)}
+	sppb.RegisterSpannerServer(server, recorder)
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+	})
+	return recorder, listener.Addr().String()
+}
+
+func TestMainSendsPriorityOnExecuteSQL(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		args     []string
+		priority sppb.RequestOptions_Priority
+	}{
+		{name: "json_eager", args: []string{"--format", "json", "--priority", "high"}, priority: sppb.RequestOptions_PRIORITY_HIGH},
+		{name: "json_lazy", args: []string{"--format", "json", "--jq-input-mode", "lazy", "--priority", "low"}, priority: sppb.RequestOptions_PRIORITY_LOW},
+		{name: "csv", args: []string{"--format", "experimental_csv", "--priority", "medium"}, priority: sppb.RequestOptions_PRIORITY_MEDIUM},
+		{name: "dml", sql: "UPDATE T SET V=1", args: []string{"--priority", "high"}, priority: sppb.RequestOptions_PRIORITY_HIGH},
+		{name: "partitioned_dml", sql: "UPDATE T SET V=1", args: []string{"--enable-partitioned-dml", "--priority", "low"}, priority: sppb.RequestOptions_PRIORITY_LOW},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder, host := startPriorityRecordingSpannerServer(t)
+			t.Setenv("SPANNER_EMULATOR_HOST", host)
+
+			sql := tt.sql
+			if sql == "" {
+				sql = "SELECT 1"
+			}
+			args := []string{"database", "--project", "project", "--instance", "instance", "--sql", sql, "--timeout", "5s"}
+			args = append(args, tt.args...)
+			err := runMain(t, args)
+			if err == nil || !strings.Contains(err.Error(), "priority test capture") {
+				t.Fatalf("_main() error = %v, want priority test capture", err)
+			}
+
+			select {
+			case req := <-recorder.requests:
+				if got := req.GetRequestOptions().GetPriority(); got != tt.priority {
+					t.Fatalf("request priority = %v, want %v", got, tt.priority)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("did not receive ExecuteStreamingSql request")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `--priority=high|medium|low|unspecified` and pass the selected priority to execute-SQL requests for queries, ordinary DML, and Partitioned DML. All existing output paths share the same query options; omitting the flag preserves unspecified priority. Read-write commit priority is unchanged.

Reject non-default priority with `--try-partition-query`: the PartitionQuery RPC has no priority field and the probe never executes the returned partitions, so accepting the flag would silently ignore it. Tests cover parsing and capture actual RPCs through the CLI for eager/lazy JSON, CSV, DML, and PDML. README help and usage are updated.

Validation: `go test ./...` (including emulator integration tests), `go build ./...`, `golangci-lint run --timeout=5m` (0 issues), `git diff --check`, and generated CLI help comparison with Go 1.25.13. Tests verify request propagation, not production scheduling behavior.
