### PR TITLE
Detect prerelease tags in GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,6 +4,10 @@
 
 version: 2
 
+release:
+  # Alpha tags must remain GitHub prereleases when the tag workflow publishes.
+  prerelease: auto
+
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
The tag workflow did not configure prerelease detection, so an alpha tag could produce a regular GitHub release. Set GoReleaser's prerelease mode to auto so prerelease tags remain prereleases.

Validation: GoReleaser 2.18.0 configuration check passed.
