### PR TITLE
Drop 386 release targets from GoReleaser builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,13 @@ builds:
       - linux
       - windows
       - darwin
+    # 64-bit only. GoReleaser's default arch list also includes 386, but no
+    # 32-bit release asset has had a non-trivial download, and upcoming
+    # dependencies (embedded Graphviz via wazero) only have an optimizing
+    # compiler on amd64/arm64.
+    goarch:
+      - amd64
+      - arm64
 
 archives:
   - formats:
@@ -27,9 +34,7 @@ archives:
       {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
       - goos: windows
         formats:


### PR DESCRIPTION
## Summary

Restrict GoReleaser builds to `amd64` and `arm64` on linux, windows, and darwin. Release archives go from eight to six; the `i386` special case in the archive name template is removed.

## Why

- GoReleaser's default `goarch` list includes `386`, so 32-bit archives were published implicitly, never by decision.
- Download counts across all releases (`gh api repos/apstndb/execspansql/releases`): 386 assets total 4 downloads, exactly one per Linux/Windows i386 asset on v0.4.0 and v0.5.0-alpha.3 and zero elsewhere, which matches automated fetchers rather than users. amd64 and arm64 totals are 7 and 6.
- A Spanner developer CLI has no realistic x86-32 audience (Windows 11 is 64-bit only; Go dropped darwin/386 long ago).
- Upcoming dependencies are 64-bit oriented: the planned embedded Graphviz plan renderer runs on wazero, which has an optimizing compiler only on amd64/arm64 and falls back to an interpreter on 386. Keeping 386 would add build and CI failure surface for a target nobody uses.

## Verification

- `goreleaser check`: configuration valid.
- `goreleaser build --snapshot --clean --skip=validate`: built exactly `linux_amd64`, `linux_arm64`, `windows_amd64`, `windows_arm64`, `darwin_amd64`, `darwin_arm64`.

## Release note

Breaking for anyone consuming the `*_i386.*` release assets: 32-bit builds are discontinued starting with the next release. `go install` on 386 hosts is unaffected.
